### PR TITLE
Link library fixes

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: win32cr
-version: 0.2.1
+version: 0.2.2
 
 authors:
   - Matthew J. Black <mjblack@gmail.com>

--- a/src/win32cr.cr
+++ b/src/win32cr.cr
@@ -13,5 +13,5 @@ struct LibC::GUID
 end
 
 module Win32cr
-  VERSION = "0.2.1"
+  VERSION = "0.2.2"
 end

--- a/src/win32cr/ai/machinelearning/directml.cr
+++ b/src/win32cr/ai/machinelearning/directml.cr
@@ -2,10 +2,18 @@ require "../../foundation.cr"
 require "../../graphics/direct3d12.cr"
 require "../../system/com.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:directml.dll")]
+{% else %}
+@[Link("directml")]
+{% end %}
 lib LibWin32
   DML_TARGET_VERSION = 16384_u32
   DML_TENSOR_DIMENSION_COUNT_MAX = 5_u32

--- a/src/win32cr/ai/machinelearning/winml.cr
+++ b/src/win32cr/ai/machinelearning/winml.cr
@@ -2,11 +2,20 @@ require "../../foundation.cr"
 require "../../graphics/direct3d12.cr"
 require "../../system/com.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:winml.dll")]
 @[Link(ldflags: "/DELAYLOAD:windows.ai.machinelearning.dll")]
+{% else %}
+@[Link("winml")]
+@[Link("windows.ai.machinelearning")]
+{% end %}
 lib LibWin32
   WINML_TENSOR_DIMENSION_COUNT_MAX = 4_u32
 

--- a/src/win32cr/data/htmlhelp.cr
+++ b/src/win32cr/data/htmlhelp.cr
@@ -3,9 +3,16 @@ require "../foundation.cr"
 require "../system/com.cr"
 require "../system/search.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   HH_DISPLAY_TOPIC = 0_u32
   HH_HELP_FINDER = 0_u32

--- a/src/win32cr/data/rightsmanagement.cr
+++ b/src/win32cr/data/rightsmanagement.cr
@@ -1,9 +1,17 @@
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:msdrm.dll")]
+{% else %}
+@[Link("msdrm")]
+{% end %}
 lib LibWin32
   DRMHANDLE_INVALID = 0_u32
   DRMENVHANDLE_INVALID = 0_u32

--- a/src/win32cr/data/xml/msxml.cr
+++ b/src/win32cr/data/xml/msxml.cr
@@ -1,9 +1,16 @@
 require "../../foundation.cr"
 require "../../system/com.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   E_XML_NOTWF = -1072897501_i32
   E_XML_NODTD = -1072897500_i32

--- a/src/win32cr/data/xml/xmllite.cr
+++ b/src/win32cr/data/xml/xmllite.cr
@@ -1,10 +1,18 @@
 require "../../system/com.cr"
 require "../../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:xmllite.dll")]
+{% else %}
+@[Link("xmllite")]
+{% end %}
 lib LibWin32
   IID_IXmlReader = "7279fc81-709d-4095-b63d-69fe4b0d9030"
   IID_IXmlWriter = "7279fc88-709d-4095-b63d-69fe4b0d9030"

--- a/src/win32cr/devices/alljoyn.cr
+++ b/src/win32cr/devices/alljoyn.cr
@@ -1,10 +1,18 @@
 require "../foundation.cr"
 require "../security.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:msajapi.dll")]
+{% else %}
+@[Link("msajapi")]
+{% end %}
 lib LibWin32
   alias Alljoyn_aboutdata = LibC::IntPtrT
   alias Alljoyn_aboutdatalistener = LibC::IntPtrT

--- a/src/win32cr/devices/biometricframework.cr
+++ b/src/win32cr/devices/biometricframework.cr
@@ -1,10 +1,18 @@
 require "../foundation.cr"
 require "../system/io.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:winbio.dll")]
+{% else %}
+@[Link("winbio")]
+{% end %}
 lib LibWin32
   WINBIO_MAX_STRING_LEN = 256_u32
   WINBIO_SCP_VERSION_1 = 1_u32

--- a/src/win32cr/devices/bluetooth.cr
+++ b/src/win32cr/devices/bluetooth.cr
@@ -1,10 +1,19 @@
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:bluetoothapis.dll")]
 @[Link(ldflags: "/DELAYLOAD:bthprops.dll")]
+{% else %}
+@[Link("bluetoothapis")]
+@[Link("bthprops")]
+{% end %}
 lib LibWin32
   alias HANDLE_SDP_TYPE = UInt64
 

--- a/src/win32cr/devices/communication.cr
+++ b/src/win32cr/devices/communication.cr
@@ -1,11 +1,18 @@
 require "../foundation.cr"
 require "../system/io.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-core-comm-l1-1-1.dll")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-core-comm-l1-1-2.dll")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+@[Link(ldflags: "/DELAYLOAD:onecore.dll")]
+{% else %}
+@[Link("onecore")]
+{% end %}
 lib LibWin32
   MDM_COMPRESSION = 1_u32
   MDM_ERROR_CONTROL = 2_u32

--- a/src/win32cr/devices/deviceaccess.cr
+++ b/src/win32cr/devices/deviceaccess.cr
@@ -1,10 +1,18 @@
 require "../system/com.cr"
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:deviceaccess.dll")]
+{% else %}
+@[Link("deviceaccess")]
+{% end %}
 lib LibWin32
   ED_BASE = 4096_i32
   DEV_PORT_SIM = 1_u32

--- a/src/win32cr/devices/deviceanddriverinstallation.cr
+++ b/src/win32cr/devices/deviceanddriverinstallation.cr
@@ -7,12 +7,22 @@ require "../ui/windowsandmessaging.cr"
 require "../graphics/gdi.cr"
 require "../data/htmlhelp.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:setupapi.dll")]
 @[Link(ldflags: "/DELAYLOAD:cfgmgr32.dll")]
 @[Link(ldflags: "/DELAYLOAD:newdev.dll")]
+{% else %}
+@[Link("setupapi")]
+@[Link("cfgmgr32")]
+@[Link("newdev")]
+{% end %}
 lib LibWin32
   alias HCMNOTIFICATION = LibC::IntPtrT
 

--- a/src/win32cr/devices/devicequery.cr
+++ b/src/win32cr/devices/devicequery.cr
@@ -1,11 +1,18 @@
 require "../devices/properties.cr"
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-devices-query-l1-1-0.dll")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-devices-query-l1-1-1.dll")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+@[Link(ldflags: "/DELAYLOAD:cfgmgr32.dll")]
+{% else %}
+@[Link("cfgmgr32")]
+{% end %}
 lib LibWin32
   alias PDEV_QUERY_RESULT_CALLBACK = Proc(HDEVQUERY__*, Void*, DEV_QUERY_RESULT_ACTION_DATA*, Void)
 

--- a/src/win32cr/devices/display.cr
+++ b/src/win32cr/devices/display.cr
@@ -7,12 +7,22 @@ require "../ui/colorsystem.cr"
 require "../system/console.cr"
 require "../graphics/direct3d9.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:dxva2.dll")]
 @[Link(ldflags: "/DELAYLOAD:gdi32.dll")]
 @[Link(ldflags: "/DELAYLOAD:user32.dll")]
+{% else %}
+@[Link("dxva2")]
+@[Link("gdi32")]
+@[Link("user32")]
+{% end %}
 lib LibWin32
   alias HSEMAPHORE = LibC::IntPtrT
   alias HSURF = LibC::IntPtrT

--- a/src/win32cr/devices/enumeration/pnp.cr
+++ b/src/win32cr/devices/enumeration/pnp.cr
@@ -3,10 +3,18 @@ require "../../security.cr"
 require "../../system/com.cr"
 require "../../devices/properties.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:cfgmgr32.dll")]
+{% else %}
+@[Link("cfgmgr32")]
+{% end %}
 lib LibWin32
   alias HSWDEVICE = LibC::IntPtrT
 

--- a/src/win32cr/devices/fax.cr
+++ b/src/win32cr/devices/fax.cr
@@ -5,12 +5,22 @@ require "../system/com.cr"
 require "../system/io.cr"
 require "../system/registry.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:winfax.dll")]
 @[Link(ldflags: "/DELAYLOAD:fxsutility.dll")]
 @[Link(ldflags: "/DELAYLOAD:sti.dll")]
+{% else %}
+@[Link("winfax")]
+@[Link("fxsutility")]
+@[Link("sti")]
+{% end %}
 lib LibWin32
   FS_INITIALIZING = 536870912_u32
   FS_DIALING = 536870913_u32

--- a/src/win32cr/devices/functiondiscovery.cr
+++ b/src/win32cr/devices/functiondiscovery.cr
@@ -3,9 +3,16 @@ require "../foundation.cr"
 require "../ui/shell/propertiessystem.cr"
 require "../system/com/structuredstorage.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   FD_EVENTID_PRIVATE = 100_u32
   FD_EVENTID = 1000_u32

--- a/src/win32cr/devices/geolocation.cr
+++ b/src/win32cr/devices/geolocation.cr
@@ -4,9 +4,16 @@ require "../ui/shell/propertiessystem.cr"
 require "../system/com/structuredstorage.cr"
 require "../devices/sensors.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   GNSS_DRIVER_VERSION_1 = 1_u32
   GNSS_DRIVER_VERSION_2 = 2_u32

--- a/src/win32cr/devices/humaninterfacedevice.cr
+++ b/src/win32cr/devices/humaninterfacedevice.cr
@@ -2,12 +2,22 @@ require "../foundation.cr"
 require "../system/com.cr"
 require "../system/registry.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:dinput8.dll")]
 @[Link(ldflags: "/DELAYLOAD:winmm.dll")]
 @[Link(ldflags: "/DELAYLOAD:hid.dll")]
+{% else %}
+@[Link("dinput8")]
+@[Link("winmm")]
+@[Link("hid")]
+{% end %}
 lib LibWin32
   DIRECTINPUT_VERSION = 2048_u32
   JOY_HW_NONE = 0_u32

--- a/src/win32cr/devices/imageacquisition.cr
+++ b/src/win32cr/devices/imageacquisition.cr
@@ -4,9 +4,16 @@ require "../system/com/structuredstorage.cr"
 require "../ui/windowsandmessaging.cr"
 require "../graphics/gdi.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   WIA_DIP_DEV_ID = 2_u32
   WIA_DIP_VEND_DESC = 3_u32

--- a/src/win32cr/devices/portabledevices.cr
+++ b/src/win32cr/devices/portabledevices.cr
@@ -4,10 +4,18 @@ require "../foundation.cr"
 require "../system/com/structuredstorage.cr"
 require "../devices/properties.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:dmprocessxmlfiltered.dll")]
+{% else %}
+@[Link("dmprocessxmlfiltered")]
+{% end %}
 lib LibWin32
   DEVPKEY_MTPBTH_IsConnected = PROPERTYKEY.new(LibC::GUID.new(0xea1237fa_u32, 0x589d_u16, 0x4472_u16, StaticArray[0x84_u8, 0xe4_u8, 0xa_u8, 0xbe_u8, 0x36_u8, 0xfd_u8, 0x62_u8, 0xef_u8]), 2_u32)
   GUID_DEVINTERFACE_WPD = "6ac27878-a6fa-4155-ba85-f98f491d4f33"

--- a/src/win32cr/devices/properties.cr
+++ b/src/win32cr/devices/properties.cr
@@ -1,8 +1,15 @@
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   DEVPKEY_DeviceInterface_Autoplay_Silent = PROPERTYKEY.new(LibC::GUID.new(0x434dd28f_u32, 0x9e75_u16, 0x450a_u16, StaticArray[0x9a_u8, 0xb9_u8, 0xff_u8, 0x61_u8, 0xe6_u8, 0x18_u8, 0xba_u8, 0xd0_u8]), 2_u32)
   DEVPKEY_NAME = PROPERTYKEY.new(LibC::GUID.new(0xb725f130_u32, 0x47ef_u16, 0x101a_u16, StaticArray[0xa5_u8, 0xf1_u8, 0x2_u8, 0x60_u8, 0x8c_u8, 0x9e_u8, 0xeb_u8, 0xac_u8]), 10_u32)

--- a/src/win32cr/devices/pwm.cr
+++ b/src/win32cr/devices/pwm.cr
@@ -1,8 +1,15 @@
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   GUID_DEVINTERFACE_PWM_CONTROLLER = "60824b4c-eed1-4c9c-b49c-1b961461a819"
   IOCTL_PWM_CONTROLLER_GET_INFO = 262144_u32

--- a/src/win32cr/devices/sensors.cr
+++ b/src/win32cr/devices/sensors.cr
@@ -4,10 +4,18 @@ require "../ui/shell/propertiessystem.cr"
 require "../system/com/structuredstorage.cr"
 require "../devices/portabledevices.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:sensorsutilsv2.dll")]
+{% else %}
+@[Link("sensorsutilsv2")]
+{% end %}
 lib LibWin32
   GUID_DEVINTERFACE_SENSOR = "ba1bb692-9b7a-4833-9a1e-525ed134e7e2"
   SENSOR_EVENT_STATE_CHANGED = "bfd96016-6bd7-4560-ad34-f2f6607e8f81"

--- a/src/win32cr/devices/serialcommunication.cr
+++ b/src/win32cr/devices/serialcommunication.cr
@@ -1,9 +1,17 @@
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:msports.dll")]
+{% else %}
+@[Link("msports")]
+{% end %}
 lib LibWin32
   alias HCOMDB = LibC::IntPtrT
 

--- a/src/win32cr/devices/tapi.cr
+++ b/src/win32cr/devices/tapi.cr
@@ -3,11 +3,20 @@ require "../foundation.cr"
 require "../media/directshow.cr"
 require "../system/addressbook.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:tapi32.dll")]
 @[Link(ldflags: "/DELAYLOAD:mapi32.dll")]
+{% else %}
+@[Link("tapi32")]
+@[Link("mapi32")]
+{% end %}
 lib LibWin32
   TAPI_CURRENT_VERSION = 131074_u32
   LINE_ADDRESSSTATE = 0_i32

--- a/src/win32cr/devices/usb.cr
+++ b/src/win32cr/devices/usb.cr
@@ -1,10 +1,18 @@
 require "../foundation.cr"
 require "../system/io.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:winusb.dll")]
+{% else %}
+@[Link("winusb")]
+{% end %}
 lib LibWin32
   SHORT_PACKET_TERMINATE = 1_u32
   AUTO_CLEAR_STALL = 2_u32

--- a/src/win32cr/devices/webservicesondevices.cr
+++ b/src/win32cr/devices/webservicesondevices.cr
@@ -3,10 +3,18 @@ require "../foundation.cr"
 require "../system/com.cr"
 require "../networking/winsock.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:wsdapi.dll")]
+{% else %}
+@[Link("wsdapi")]
+{% end %}
 lib LibWin32
   WSDAPI_OPTION_MAX_INBOUND_MESSAGE_SIZE = 1_u32
   WSDAPI_OPTION_TRACE_XML_TO_DEBUGGER = 2_u32

--- a/src/win32cr/foundation.cr
+++ b/src/win32cr/foundation.cr
@@ -1,10 +1,20 @@
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
-@[Link("oleaut32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-core-handle-l1-1-0.dll")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+@[Link(ldflags: "/DELAYLOAD:oleaut32.dll")]
+@[Link(ldflags: "/DELAYLOAD:onecore.dll")]
 @[Link(ldflags: "/DELAYLOAD:user32.dll")]
+{% else %}
+@[Link("oleaut32")]
+@[Link("onecore")]
+@[Link("user32")]
+{% end %}
 lib LibWin32
   alias BOOL = LibC::BOOL
   alias BOOLEAN = UInt8

--- a/src/win32cr/gaming.cr
+++ b/src/win32cr/gaming.cr
@@ -2,16 +2,18 @@ require "./system/com.cr"
 require "./foundation.cr"
 require "./system/winrt.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-gaming-expandedresources-l1-1-0.dll")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-gaming-deviceinformation-l1-1-0.dll")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-gaming-tcui-l1-1-0.dll")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-gaming-tcui-l1-1-1.dll")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-gaming-tcui-l1-1-2.dll")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-gaming-tcui-l1-1-3.dll")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-gaming-tcui-l1-1-4.dll")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+@[Link(ldflags: "/DELAYLOAD:onecore.dll")]
+{% else %}
+@[Link("onecore")]
+{% end %}
 lib LibWin32
   GameExplorer = LibC::GUID.new(0x9a5ea990_u32, 0x3034_u16, 0x4d6f_u16, StaticArray[0x91_u8, 0x28_u8, 0x1_u8, 0xf3_u8, 0xc6_u8, 0x10_u8, 0x22_u8, 0xbc_u8])
   GameStatistics = LibC::GUID.new(0xdbc85a2c_u32, 0xc0dc_u16, 0x4961_u16, StaticArray[0xb6_u8, 0xe2_u8, 0xd2_u8, 0x8b_u8, 0x62_u8, 0xc1_u8, 0x1a_u8, 0xd4_u8])

--- a/src/win32cr/globalization.cr
+++ b/src/win32cr/globalization.cr
@@ -2,9 +2,14 @@ require "./graphics/gdi.cr"
 require "./foundation.cr"
 require "./system/com.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:gdi32.dll")]
 @[Link(ldflags: "/DELAYLOAD:normaliz.dll")]
 @[Link(ldflags: "/DELAYLOAD:elscore.dll")]
@@ -12,6 +17,15 @@ require "./system/com.cr"
 @[Link(ldflags: "/DELAYLOAD:icu.dll")]
 @[Link(ldflags: "/DELAYLOAD:bcp47mrm.dll")]
 @[Link(ldflags: "/DELAYLOAD:advapi32.dll")]
+{% else %}
+@[Link("gdi32")]
+@[Link("normaliz")]
+@[Link("elscore")]
+@[Link("usp10")]
+@[Link("icu")]
+@[Link("bcp47mrm")]
+@[Link("advapi32")]
+{% end %}
 lib LibWin32
   alias HIMC = LibC::IntPtrT
   alias HIMCC = LibC::IntPtrT

--- a/src/win32cr/graphics.cr
+++ b/src/win32cr/graphics.cr
@@ -1,6 +1,13 @@
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
 
   enum D2D1_2DAFFINETRANSFORM_INTERPOLATION_MODE : UInt32

--- a/src/win32cr/graphics/compositionswapchain.cr
+++ b/src/win32cr/graphics/compositionswapchain.cr
@@ -2,10 +2,18 @@ require "../system/com.cr"
 require "../foundation.cr"
 require "../graphics/dxgi/common.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:dcomp.dll")]
+{% else %}
+@[Link("dcomp")]
+{% end %}
 lib LibWin32
 
   enum PresentStatisticsKind : Int32

--- a/src/win32cr/graphics/direct2d.cr
+++ b/src/win32cr/graphics/direct2d.cr
@@ -9,10 +9,18 @@ require "../graphics/dxgi/common.cr"
 require "../storage/xps/printing.cr"
 require "../graphics/direct3d.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:d2d1.dll")]
+{% else %}
+@[Link("d2d1")]
+{% end %}
 lib LibWin32
   D2D1_DEFAULT_FLATTENING_TOLERANCE = "0.25_f32"
   CLSID_D2D12DAffineTransform = "6aa97485-6354-4cfc-908c-e4a74f62c96c"

--- a/src/win32cr/graphics/direct2d/common.cr
+++ b/src/win32cr/graphics/direct2d/common.cr
@@ -2,9 +2,16 @@ require "../../graphics/dxgi/common.cr"
 require "../../system/com.cr"
 require "../../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
 
   enum D2D1_ALPHA_MODE : UInt32

--- a/src/win32cr/graphics/direct3d.cr
+++ b/src/win32cr/graphics/direct3d.cr
@@ -1,9 +1,16 @@
 require "../foundation.cr"
 require "../system/com.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   D3D_FL9_1_REQ_TEXTURE1D_U_DIMENSION = 2048_u32
   D3D_FL9_3_REQ_TEXTURE1D_U_DIMENSION = 4096_u32

--- a/src/win32cr/graphics/direct3d/dxc.cr
+++ b/src/win32cr/graphics/direct3d/dxc.cr
@@ -1,10 +1,18 @@
 require "../../foundation.cr"
 require "../../system/com.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:dxcompiler.dll")]
+{% else %}
+@[Link("dxcompiler")]
+{% end %}
 lib LibWin32
   DXC_HASHFLAG_INCLUDES_SOURCE = 1_u32
   DxcValidatorFlags_Default = 0_u32

--- a/src/win32cr/graphics/direct3d/fxc.cr
+++ b/src/win32cr/graphics/direct3d/fxc.cr
@@ -3,10 +3,18 @@ require "../../graphics/direct3d.cr"
 require "../../graphics/direct3d11.cr"
 require "../../graphics/direct3d10.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:d3dcompiler_47.dll")]
+{% else %}
+@[Link("d3dcompiler_47")]
+{% end %}
 lib LibWin32
   D3D_COMPILER_VERSION = 47_u32
   D3DCOMPILE_DEBUG = 1_u32

--- a/src/win32cr/graphics/direct3d10.cr
+++ b/src/win32cr/graphics/direct3d10.cr
@@ -4,11 +4,20 @@ require "../system/com.cr"
 require "../graphics/direct3d.cr"
 require "../graphics/dxgi.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:d3d10.dll")]
 @[Link(ldflags: "/DELAYLOAD:d3d10_1.dll")]
+{% else %}
+@[Link("d3d10")]
+@[Link("d3d10_1")]
+{% end %}
 lib LibWin32
   D3D10_16BIT_INDEX_STRIP_CUT_VALUE = 65535_u32
   D3D10_32BIT_INDEX_STRIP_CUT_VALUE = 4294967295_u32

--- a/src/win32cr/graphics/direct3d11.cr
+++ b/src/win32cr/graphics/direct3d11.cr
@@ -5,12 +5,22 @@ require "../graphics/direct3d.cr"
 require "../graphics/dxgi.cr"
 require "../security.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:d3d11.dll")]
 @[Link(ldflags: "/DELAYLOAD:d3dcompiler_47.dll")]
 @[Link(ldflags: "/DELAYLOAD:d3dcsx.dll")]
+{% else %}
+@[Link("d3d11")]
+@[Link("d3dcompiler_47")]
+@[Link("d3dcsx")]
+{% end %}
 lib LibWin32
   D3D11_16BIT_INDEX_STRIP_CUT_VALUE = 65535_u32
   D3D11_32BIT_INDEX_STRIP_CUT_VALUE = 4294967295_u32

--- a/src/win32cr/graphics/direct3d11on12.cr
+++ b/src/win32cr/graphics/direct3d11on12.cr
@@ -4,10 +4,18 @@ require "../graphics/direct3d.cr"
 require "../graphics/direct3d11.cr"
 require "../graphics/direct3d12.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:d3d11.dll")]
+{% else %}
+@[Link("d3d11")]
+{% end %}
 lib LibWin32
   alias PFN_D3D11ON12_CREATE_DEVICE = Proc(IUnknown, UInt32, D3D_FEATURE_LEVEL*, UInt32, IUnknown*, UInt32, UInt32, ID3D11Device*, ID3D11DeviceContext*, D3D_FEATURE_LEVEL*, HRESULT)
 

--- a/src/win32cr/graphics/direct3d12.cr
+++ b/src/win32cr/graphics/direct3d12.cr
@@ -4,10 +4,18 @@ require "../system/com.cr"
 require "../graphics/direct3d.cr"
 require "../security.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:d3d12.dll")]
+{% else %}
+@[Link("d3d12")]
+{% end %}
 lib LibWin32
   D3D12_SHADER_COMPONENT_MAPPING_ALWAYS_SET_BIT_AVOIDING_ZEROMEM_MISTAKES = 4096_u32
   D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING = 5768_u32

--- a/src/win32cr/graphics/direct3d9.cr
+++ b/src/win32cr/graphics/direct3d9.cr
@@ -3,10 +3,18 @@ require "../foundation.cr"
 require "../system/com.cr"
 require "../graphics/gdi.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:d3d9.dll")]
+{% else %}
+@[Link("d3d9")]
+{% end %}
 lib LibWin32
   D3DRTYPECOUNT = 8_u32
   D3DCS_LEFT = 1_i32

--- a/src/win32cr/graphics/direct3d9on12.cr
+++ b/src/win32cr/graphics/direct3d9on12.cr
@@ -3,10 +3,18 @@ require "../system/com.cr"
 require "../graphics/direct3d9.cr"
 require "../graphics/direct3d12.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:d3d9.dll")]
+{% else %}
+@[Link("d3d9")]
+{% end %}
 lib LibWin32
   MAX_D3D9ON12_QUEUES = 2_u32
 

--- a/src/win32cr/graphics/directcomposition.cr
+++ b/src/win32cr/graphics/directcomposition.cr
@@ -7,10 +7,18 @@ require "../graphics.cr"
 require "../graphics/dxgi.cr"
 require "../security.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:dcomp.dll")]
+{% else %}
+@[Link("dcomp")]
+{% end %}
 lib LibWin32
   COMPOSITIONOBJECT_READ = 1_i32
   COMPOSITIONOBJECT_WRITE = 2_i32

--- a/src/win32cr/graphics/directdraw.cr
+++ b/src/win32cr/graphics/directdraw.cr
@@ -2,10 +2,18 @@ require "../foundation.cr"
 require "../graphics/gdi.cr"
 require "../system/com.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:ddraw.dll")]
+{% else %}
+@[Link("ddraw")]
+{% end %}
 lib LibWin32
   DIRECTDRAW_VERSION = 1792_u32
   FACDD = 2166_u32

--- a/src/win32cr/graphics/directmanipulation.cr
+++ b/src/win32cr/graphics/directmanipulation.cr
@@ -2,9 +2,16 @@ require "../system/com.cr"
 require "../foundation.cr"
 require "../ui/windowsandmessaging.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   DIRECTMANIPULATION_KEYBOARDFOCUS = 4294967294_u32
   DIRECTMANIPULATION_MOUSEFOCUS = 4294967293_u32

--- a/src/win32cr/graphics/directwrite.cr
+++ b/src/win32cr/graphics/directwrite.cr
@@ -4,10 +4,18 @@ require "../graphics/direct2d/common.cr"
 require "../graphics/gdi.cr"
 require "../globalization.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:dwrite.dll")]
+{% else %}
+@[Link("dwrite")]
+{% end %}
 lib LibWin32
   DWRITE_ALPHA_MAX = 255_u32
   FACILITY_DWRITE = 2200_u32

--- a/src/win32cr/graphics/dwm.cr
+++ b/src/win32cr/graphics/dwm.cr
@@ -2,10 +2,18 @@ require "../foundation.cr"
 require "../graphics/gdi.cr"
 require "../ui/controls.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:dwmapi.dll")]
+{% else %}
+@[Link("dwmapi")]
+{% end %}
 lib LibWin32
   DWM_BB_ENABLE = 1_u32
   DWM_BB_BLURREGION = 2_u32

--- a/src/win32cr/graphics/dxcore.cr
+++ b/src/win32cr/graphics/dxcore.cr
@@ -1,10 +1,18 @@
 require "../system/com.cr"
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:dxcore.dll")]
+{% else %}
+@[Link("dxcore")]
+{% end %}
 lib LibWin32
   FACDXCORE = 2176_u32
   DXCORE_ADAPTER_ATTRIBUTE_D3D11_GRAPHICS = "8c47866b-7583-450d-f0f0-6bada895af4b"

--- a/src/win32cr/graphics/dxgi.cr
+++ b/src/win32cr/graphics/dxgi.cr
@@ -4,10 +4,18 @@ require "../graphics/gdi.cr"
 require "../system/com.cr"
 require "../security.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:dxgi.dll")]
+{% else %}
+@[Link("dxgi")]
+{% end %}
 lib LibWin32
   DXGI_USAGE_SHADER_INPUT = 16_u32
   DXGI_USAGE_RENDER_TARGET_OUTPUT = 32_u32

--- a/src/win32cr/graphics/dxgi/common.cr
+++ b/src/win32cr/graphics/dxgi/common.cr
@@ -1,8 +1,15 @@
 require "../../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   FACDXGI = 2170_u32
   DXGI_CPU_ACCESS_NONE = 0_u32

--- a/src/win32cr/graphics/gdi.cr
+++ b/src/win32cr/graphics/gdi.cr
@@ -1,14 +1,27 @@
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:gdi32.dll")]
 @[Link(ldflags: "/DELAYLOAD:msimg32.dll")]
 @[Link(ldflags: "/DELAYLOAD:opengl32.dll")]
 @[Link(ldflags: "/DELAYLOAD:fontsub.dll")]
 @[Link(ldflags: "/DELAYLOAD:t2embed.dll")]
 @[Link(ldflags: "/DELAYLOAD:user32.dll")]
+{% else %}
+@[Link("gdi32")]
+@[Link("msimg32")]
+@[Link("opengl32")]
+@[Link("fontsub")]
+@[Link("t2embed")]
+@[Link("user32")]
+{% end %}
 lib LibWin32
   alias HDC = LibC::IntPtrT
   alias CreatedHDC = LibC::IntPtrT

--- a/src/win32cr/graphics/hlsl.cr
+++ b/src/win32cr/graphics/hlsl.cr
@@ -1,6 +1,13 @@
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   D3DCOMPILER_DLL = "d3dcompiler_47.dll"
   D3DCOMPILE_OPTIMIZATION_LEVEL2 = 49152_u32

--- a/src/win32cr/graphics/imaging.cr
+++ b/src/win32cr/graphics/imaging.cr
@@ -6,10 +6,18 @@ require "../graphics/gdi.cr"
 require "../ui/windowsandmessaging.cr"
 require "../graphics/dxgi/common.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:windowscodecs.dll")]
+{% else %}
+@[Link("windowscodecs")]
+{% end %}
 lib LibWin32
   WINCODEC_SDK_VERSION1 = 566_u32
   WINCODEC_SDK_VERSION2 = 567_u32

--- a/src/win32cr/graphics/imaging/d2d.cr
+++ b/src/win32cr/graphics/imaging/d2d.cr
@@ -3,9 +3,16 @@ require "../../foundation.cr"
 require "../../graphics/direct2d.cr"
 require "../../graphics/imaging.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
 
   struct IWICImageEncoderVTbl

--- a/src/win32cr/graphics/opengl.cr
+++ b/src/win32cr/graphics/opengl.cr
@@ -1,12 +1,22 @@
 require "../graphics/gdi.cr"
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:gdi32.dll")]
 @[Link(ldflags: "/DELAYLOAD:opengl32.dll")]
 @[Link(ldflags: "/DELAYLOAD:glu32.dll")]
+{% else %}
+@[Link("gdi32")]
+@[Link("opengl32")]
+@[Link("glu32")]
+{% end %}
 lib LibWin32
   alias HGLRC = LibC::IntPtrT
 

--- a/src/win32cr/graphics/printing.cr
+++ b/src/win32cr/graphics/printing.cr
@@ -10,14 +10,26 @@ require "../graphics/imaging.cr"
 require "../storage/xps.cr"
 require "../graphics/dxgi.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:compstui.dll")]
 @[Link(ldflags: "/DELAYLOAD:winspool.dll")]
 @[Link(ldflags: "/DELAYLOAD:gdi32.dll")]
 @[Link(ldflags: "/DELAYLOAD:spoolss.dll")]
 @[Link(ldflags: "/DELAYLOAD:mscms.dll")]
+{% else %}
+@[Link("compstui")]
+@[Link("winspool")]
+@[Link("gdi32")]
+@[Link("spoolss")]
+@[Link("mscms")]
+{% end %}
 lib LibWin32
   USB_PRINTER_INTERFACE_CLASSIC = 1_u32
   USB_PRINTER_INTERFACE_IPP = 2_u32

--- a/src/win32cr/graphics/printing/printticket.cr
+++ b/src/win32cr/graphics/printing/printticket.cr
@@ -3,10 +3,18 @@ require "../../storage/xps.cr"
 require "../../system/com.cr"
 require "../../graphics/gdi.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:prntvpt.dll")]
+{% else %}
+@[Link("prntvpt")]
+{% end %}
 lib LibWin32
   PRINTTICKET_ISTREAM_APIS = 1_u32
   S_PT_NO_CONFLICT = 262145_u32

--- a/src/win32cr/management/mobiledevicemanagementregistration.cr
+++ b/src/win32cr/management/mobiledevicemanagementregistration.cr
@@ -1,10 +1,19 @@
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:mdmregistration.dll")]
 @[Link(ldflags: "/DELAYLOAD:mdmlocalmanagement.dll")]
+{% else %}
+@[Link("mdmregistration")]
+@[Link("mdmlocalmanagement")]
+{% end %}
 lib LibWin32
   MENROLL_E_DEVICE_MESSAGE_FORMAT_ERROR = -2145910783_i32
   MENROLL_E_DEVICE_AUTHENTICATION_ERROR = -2145910782_i32

--- a/src/win32cr/media.cr
+++ b/src/win32cr/media.cr
@@ -2,10 +2,18 @@ require "./media/multimedia.cr"
 require "./system/com.cr"
 require "./foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:winmm.dll")]
+{% else %}
+@[Link("winmm")]
+{% end %}
 lib LibWin32
   alias HTASK = LibC::IntPtrT
 

--- a/src/win32cr/media/audio.cr
+++ b/src/win32cr/media/audio.cr
@@ -6,14 +6,26 @@ require "../system/com/structuredstorage.cr"
 require "../ui/shell/propertiessystem.cr"
 require "../ui/windowsandmessaging.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:ole32.dll")]
 @[Link(ldflags: "/DELAYLOAD:winmm.dll")]
 @[Link(ldflags: "/DELAYLOAD:mmdevapi.dll")]
 @[Link(ldflags: "/DELAYLOAD:windows.media.mediacontrol.dll")]
 @[Link(ldflags: "/DELAYLOAD:msacm32.dll")]
+{% else %}
+@[Link("ole32")]
+@[Link("winmm")]
+@[Link("mmdevapi")]
+@[Link("windows.media.mediacontrol")]
+@[Link("msacm32")]
+{% end %}
 lib LibWin32
   alias HMIDI = LibC::IntPtrT
   alias HMIDIIN = LibC::IntPtrT

--- a/src/win32cr/media/audio/apo.cr
+++ b/src/win32cr/media/audio/apo.cr
@@ -3,9 +3,16 @@ require "../../foundation.cr"
 require "../../media/audio.cr"
 require "../../ui/shell/propertiessystem.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   APOERR_ALREADY_INITIALIZED = -2005073919_i32
   APOERR_NOT_INITIALIZED = -2005073918_i32

--- a/src/win32cr/media/audio/directmusic.cr
+++ b/src/win32cr/media/audio/directmusic.cr
@@ -6,9 +6,16 @@ require "../../media/audio/directsound.cr"
 require "../../system/io.cr"
 require "../../media/multimedia.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   DMUS_MAX_DESCRIPTION = 128_u32
   DMUS_MAX_DRIVER = 128_u32

--- a/src/win32cr/media/audio/directsound.cr
+++ b/src/win32cr/media/audio/directsound.cr
@@ -3,10 +3,18 @@ require "../../graphics/direct3d.cr"
 require "../../foundation.cr"
 require "../../system/com.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:dsound.dll")]
+{% else %}
+@[Link("dsound")]
+{% end %}
 lib LibWin32
   DIRECTSOUND_VERSION = 1792_u32
   FACDS = 2168_u32

--- a/src/win32cr/media/audio/endpoints.cr
+++ b/src/win32cr/media/audio/endpoints.cr
@@ -4,9 +4,16 @@ require "../../media/audio.cr"
 require "../../media/kernelstreaming.cr"
 require "../../media/audio/apo.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   DEVPKEY_AudioEndpointPlugin_FactoryCLSID = PROPERTYKEY.new(LibC::GUID.new(0x12d83bd7_u32, 0xcf12_u16, 0x46be_u16, StaticArray[0x85_u8, 0x40_u8, 0x81_u8, 0x27_u8, 0x10_u8, 0xd3_u8, 0x2_u8, 0x1c_u8]), 1_u32)
   DEVPKEY_AudioEndpointPlugin_DataFlow = PROPERTYKEY.new(LibC::GUID.new(0x12d83bd7_u32, 0xcf12_u16, 0x46be_u16, StaticArray[0x85_u8, 0x40_u8, 0x81_u8, 0x27_u8, 0x10_u8, 0xd3_u8, 0x2_u8, 0x1c_u8]), 2_u32)

--- a/src/win32cr/media/audio/xaudio2.cr
+++ b/src/win32cr/media/audio/xaudio2.cr
@@ -2,11 +2,20 @@ require "../../media/audio.cr"
 require "../../system/com.cr"
 require "../../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:xaudio2_8.dll")]
 @[Link(ldflags: "/DELAYLOAD:hrtfapo.dll")]
+{% else %}
+@[Link("xaudio2_8")]
+@[Link("hrtfapo")]
+{% end %}
 lib LibWin32
   FXEQ_MIN_FRAMERATE = 22000_u32
   FXEQ_MAX_FRAMERATE = 48000_u32

--- a/src/win32cr/media/devicemanager.cr
+++ b/src/win32cr/media/devicemanager.cr
@@ -3,9 +3,16 @@ require "../system/com/structuredstorage.cr"
 require "../system/com.cr"
 require "../system/ole.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   IOCTL_MTP_CUSTOM_COMMAND = 827348045_u32
   MTP_NEXTPHASE_READ_DATA = 1_u32

--- a/src/win32cr/media/directshow.cr
+++ b/src/win32cr/media/directshow.cr
@@ -15,10 +15,18 @@ require "../media/mediafoundation.cr"
 require "../system/diagnostics/etw.cr"
 require "../system/ole.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:quartz.dll")]
+{% else %}
+@[Link("quartz")]
+{% end %}
 lib LibWin32
   EC_SND_DEVICE_ERROR_BASE = 512_u32
   EC_SNDDEV_IN_ERROR = 512_u32

--- a/src/win32cr/media/directshow/xml.cr
+++ b/src/win32cr/media/directshow/xml.cr
@@ -3,9 +3,16 @@ require "../../foundation.cr"
 require "../../media/directshow.cr"
 require "../../data/xml/msxml.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   CLSID_XMLGraphBuilder = "1bb05961-5fbf-11d2-a521-44df07c10000"
 

--- a/src/win32cr/media/dxmediaobjects.cr
+++ b/src/win32cr/media/dxmediaobjects.cr
@@ -1,10 +1,18 @@
 require "../foundation.cr"
 require "../system/com.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:msdmo.dll")]
+{% else %}
+@[Link("msdmo")]
+{% end %}
 lib LibWin32
   DMO_E_INVALIDSTREAMINDEX = -2147220991_i32
   DMO_E_INVALIDTYPE = -2147220990_i32

--- a/src/win32cr/media/kernelstreaming.cr
+++ b/src/win32cr/media/kernelstreaming.cr
@@ -2,10 +2,18 @@ require "../system/com.cr"
 require "../foundation.cr"
 require "../media.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:ksuser.dll")]
+{% else %}
+@[Link("ksuser")]
+{% end %}
 lib LibWin32
   IOCTL_KS_PROPERTY = 3080195_u32
   IOCTL_KS_ENABLE_EVENT = 3080199_u32

--- a/src/win32cr/media/librarysharingservices.cr
+++ b/src/win32cr/media/librarysharingservices.cr
@@ -1,9 +1,16 @@
 require "../system/com.cr"
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   WindowsMediaLibrarySharingServices = LibC::GUID.new(0xad581b00_u32, 0x7b64_u16, 0x4e59_u16, StaticArray[0xa3_u8, 0x8d_u8, 0xd2_u8, 0xc5_u8, 0xbf_u8, 0x51_u8, 0xdd_u8, 0xb3_u8])
 

--- a/src/win32cr/media/mediafoundation.cr
+++ b/src/win32cr/media/mediafoundation.cr
@@ -13,9 +13,14 @@ require "../system/winrt.cr"
 require "../devices/properties.cr"
 require "../media/directshow.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:dxva2.dll")]
 @[Link(ldflags: "/DELAYLOAD:mfplat.dll")]
 @[Link(ldflags: "/DELAYLOAD:mf.dll")]
@@ -26,6 +31,18 @@ require "../media/directshow.cr"
 @[Link(ldflags: "/DELAYLOAD:mfreadwrite.dll")]
 @[Link(ldflags: "/DELAYLOAD:mfplay.dll")]
 @[Link(ldflags: "/DELAYLOAD:opmxbox.dll")]
+{% else %}
+@[Link("dxva2")]
+@[Link("mfplat")]
+@[Link("mf")]
+@[Link("mfsrcsnk")]
+@[Link("mfsensorgroup")]
+@[Link("mfcore")]
+@[Link("evr")]
+@[Link("mfreadwrite")]
+@[Link("mfplay")]
+@[Link("opmxbox")]
+{% end %}
 lib LibWin32
   MEDIASUBTYPE_None = "e436eb8e-524f-11ce-9f53-0020af0ba770"
   AVENC_H263V_LEVELCOUNT = 8_u32

--- a/src/win32cr/media/mediaplayer.cr
+++ b/src/win32cr/media/mediaplayer.cr
@@ -5,9 +5,16 @@ require "../system/ole.cr"
 require "../graphics/gdi.cr"
 require "../ui/windowsandmessaging.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   CLSID_XFeedsManager = "fe6b11c3-c72e-4061-86c6-9d163121f229"
   WMPGC_FLAGS_ALLOW_PREROLL = 1_u32

--- a/src/win32cr/media/multimedia.cr
+++ b/src/win32cr/media/multimedia.cr
@@ -7,14 +7,22 @@ require "../ui/controls.cr"
 require "../system/io.cr"
 require "../ui/controls/dialogs.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:winmm.dll")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-mm-misc-l1-1-1.dll")]
-@[Link(ldflags: "/DELAYLOAD:msvfw32.dll")]
+@[Link(ldflags: "/DELAYLOAD:vfw32.dll")]
 @[Link(ldflags: "/DELAYLOAD:avifil32.dll")]
-@[Link(ldflags: "/DELAYLOAD:avicap32.dll")]
+{% else %}
+@[Link("winmm")]
+@[Link("vfw32")]
+@[Link("avifil32")]
+{% end %}
 lib LibWin32
   alias HMMIO = LibC::IntPtrT
   alias HDRVR = LibC::IntPtrT

--- a/src/win32cr/media/pictureacquisition.cr
+++ b/src/win32cr/media/pictureacquisition.cr
@@ -5,9 +5,16 @@ require "../ui/shell/propertiessystem.cr"
 require "../system/com/structuredstorage.cr"
 require "../ui/windowsandmessaging.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   PKEY_PhotoAcquire_RelativePathname = PROPERTYKEY.new(LibC::GUID.new(0xf23377_u32, 0x7ac6_u16, 0x4b7a_u16, StaticArray[0x84_u8, 0x43_u8, 0x34_u8, 0x5e_u8, 0x73_u8, 0x1f_u8, 0xa5_u8, 0x7a_u8]), 2_u32)
   PKEY_PhotoAcquire_FinalFilename = PROPERTYKEY.new(LibC::GUID.new(0xf23377_u32, 0x7ac6_u16, 0x4b7a_u16, StaticArray[0x84_u8, 0x43_u8, 0x34_u8, 0x5e_u8, 0x73_u8, 0x1f_u8, 0xa5_u8, 0x7a_u8]), 3_u32)

--- a/src/win32cr/media/speech.cr
+++ b/src/win32cr/media/speech.cr
@@ -4,9 +4,16 @@ require "../system/registry.cr"
 require "../media/audio.cr"
 require "../system/com/urlmon.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   SP_LOW_CONFIDENCE = -1_i32
   SP_NORMAL_CONFIDENCE = 0_u32

--- a/src/win32cr/media/streaming.cr
+++ b/src/win32cr/media/streaming.cr
@@ -2,9 +2,16 @@ require "../system/com.cr"
 require "../foundation.cr"
 require "../media/mediafoundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
 
   enum MF_TRANSFER_VIDEO_FRAME_FLAGS : Int32

--- a/src/win32cr/media/windowsmediaformat.cr
+++ b/src/win32cr/media/windowsmediaformat.cr
@@ -3,10 +3,18 @@ require "../foundation.cr"
 require "../media/directshow.cr"
 require "../graphics/gdi.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:wmvcore.dll")]
+{% else %}
+@[Link("wmvcore")]
+{% end %}
 lib LibWin32
   WMT_VIDEOIMAGE_SAMPLE_INPUT_FRAME = 1_u32
   WMT_VIDEOIMAGE_SAMPLE_OUTPUT_FRAME = 2_u32

--- a/src/win32cr/networking/activedirectory.cr
+++ b/src/win32cr/networking/activedirectory.cr
@@ -10,15 +10,28 @@ require "../security.cr"
 require "../networking/winsock.cr"
 require "../security/authentication/identity.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:activeds.dll")]
 @[Link(ldflags: "/DELAYLOAD:dsuiext.dll")]
 @[Link(ldflags: "/DELAYLOAD:dsprop.dll")]
 @[Link(ldflags: "/DELAYLOAD:dsparse.dll")]
 @[Link(ldflags: "/DELAYLOAD:ntdsapi.dll")]
 @[Link(ldflags: "/DELAYLOAD:netapi32.dll")]
+{% else %}
+@[Link("activeds")]
+@[Link("dsuiext")]
+@[Link("dsprop")]
+@[Link("dsparse")]
+@[Link("ntdsapi")]
+@[Link("netapi32")]
+{% end %}
 lib LibWin32
   alias GetDcContextHandle = LibC::IntPtrT
 

--- a/src/win32cr/networking/backgroundintelligenttransferservice.cr
+++ b/src/win32cr/networking/backgroundintelligenttransferservice.cr
@@ -1,9 +1,16 @@
 require "../foundation.cr"
 require "../system/com.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   BG_NOTIFY_JOB_TRANSFERRED = 1_u32
   BG_NOTIFY_JOB_ERROR = 2_u32

--- a/src/win32cr/networking/clustering.cr
+++ b/src/win32cr/networking/clustering.cr
@@ -6,12 +6,22 @@ require "../system/com.cr"
 require "../graphics/gdi.cr"
 require "../ui/windowsandmessaging.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:clusapi.dll")]
 @[Link(ldflags: "/DELAYLOAD:resutils.dll")]
 @[Link(ldflags: "/DELAYLOAD:ntlanman.dll")]
+{% else %}
+@[Link("clusapi")]
+@[Link("resutils")]
+@[Link("ntlanman")]
+{% end %}
 lib LibWin32
   CLUSTER_VERSION_FLAG_MIXED_MODE = 1_u32
   CLUSTER_VERSION_UNKNOWN = 4294967295_u32

--- a/src/win32cr/networking/httpserver.cr
+++ b/src/win32cr/networking/httpserver.cr
@@ -3,10 +3,18 @@ require "../security.cr"
 require "../networking/winsock.cr"
 require "../system/io.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:httpapi.dll")]
+{% else %}
+@[Link("httpapi")]
+{% end %}
 lib LibWin32
   HTTP_DEMAND_CBT = 4_u32
   HTTP_MAX_SERVER_QUEUE_LENGTH = 2147483647_u32

--- a/src/win32cr/networking/ldap.cr
+++ b/src/win32cr/networking/ldap.cr
@@ -2,10 +2,18 @@ require "../foundation.cr"
 require "../security/authentication/identity.cr"
 require "../security/cryptography.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:wldap32.dll")]
+{% else %}
+@[Link("wldap32")]
+{% end %}
 lib LibWin32
   LBER_ERROR = -1_i32
   LBER_DEFAULT = -1_i32

--- a/src/win32cr/networking/networklistmanager.cr
+++ b/src/win32cr/networking/networklistmanager.cr
@@ -2,9 +2,16 @@ require "../foundation.cr"
 require "../system/com.cr"
 require "../system/ole.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   NLM_MAX_ADDRESS_LIST_SIZE = 10_u32
   NLM_UNKNOWN_DATAPLAN_STATUS = 4294967295_u32

--- a/src/win32cr/networking/remotedifferentialcompression.cr
+++ b/src/win32cr/networking/remotedifferentialcompression.cr
@@ -1,9 +1,16 @@
 require "../system/com.cr"
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   RDCE_TABLE_FULL = 2147745793_u32
   RDCE_TABLE_CORRUPT = 2147745794_u32

--- a/src/win32cr/networking/websocket.cr
+++ b/src/win32cr/networking/websocket.cr
@@ -1,9 +1,17 @@
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:websocket.dll")]
+{% else %}
+@[Link("websocket")]
+{% end %}
 lib LibWin32
   alias WEB_SOCKET_HANDLE = LibC::IntPtrT
 

--- a/src/win32cr/networking/windowswebservices.cr
+++ b/src/win32cr/networking/windowswebservices.cr
@@ -3,11 +3,20 @@ require "../security/cryptography.cr"
 require "../security/authentication/identity.cr"
 require "../system/winrt.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:webservices.dll")]
 @[Link(ldflags: "/DELAYLOAD:webauthn.dll")]
+{% else %}
+@[Link("webservices")]
+@[Link("webauthn")]
+{% end %}
 lib LibWin32
   WEBAUTHN_API_VERSION_1 = 1_u32
   WEBAUTHN_API_VERSION_2 = 2_u32

--- a/src/win32cr/networking/winhttp.cr
+++ b/src/win32cr/networking/winhttp.cr
@@ -1,10 +1,18 @@
 require "../foundation.cr"
 require "../networking/winsock.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:winhttp.dll")]
+{% else %}
+@[Link("winhttp")]
+{% end %}
 lib LibWin32
   WINHTTP_FLAG_ASYNC = 268435456_u32
   WINHTTP_FLAG_SECURE_DEFAULTS = 805306368_u32

--- a/src/win32cr/networking/wininet.cr
+++ b/src/win32cr/networking/wininet.cr
@@ -7,10 +7,18 @@ require "../system/winrt.cr"
 require "../networking/winhttp.cr"
 require "../storage/filesystem.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:wininet.dll")]
+{% else %}
+@[Link("wininet")]
+{% end %}
 lib LibWin32
   alias HTTP_PUSH_WAIT_HANDLE = LibC::IntPtrT
 

--- a/src/win32cr/networking/winsock.cr
+++ b/src/win32cr/networking/winsock.cr
@@ -5,13 +5,24 @@ require "../system/io.cr"
 require "../system/com.cr"
 require "../networkmanagement/windowsfilteringplatform.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:ws2_32.dll")]
 @[Link(ldflags: "/DELAYLOAD:mswsock.dll")]
 @[Link(ldflags: "/DELAYLOAD:fwpuclnt.dll")]
 @[Link(ldflags: "/DELAYLOAD:windows.networking.dll")]
+{% else %}
+@[Link("ws2_32")]
+@[Link("mswsock")]
+@[Link("fwpuclnt")]
+@[Link("windows.networking")]
+{% end %}
 lib LibWin32
   alias HWSAEVENT = LibC::IntPtrT
   alias SOCKET = LibC::UINT_PTR

--- a/src/win32cr/networkmanagement/dhcp.cr
+++ b/src/win32cr/networkmanagement/dhcp.cr
@@ -1,11 +1,21 @@
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:dhcpcsvc6.dll")]
 @[Link(ldflags: "/DELAYLOAD:dhcpcsvc.dll")]
 @[Link(ldflags: "/DELAYLOAD:dhcpsapi.dll")]
+{% else %}
+@[Link("dhcpcsvc6")]
+@[Link("dhcpcsvc")]
+@[Link("dhcpsapi")]
+{% end %}
 lib LibWin32
   OPTION_PAD = 0_u32
   OPTION_SUBNET_MASK = 1_u32

--- a/src/win32cr/networkmanagement/dns.cr
+++ b/src/win32cr/networkmanagement/dns.cr
@@ -1,9 +1,17 @@
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:dnsapi.dll")]
+{% else %}
+@[Link("dnsapi")]
+{% end %}
 lib LibWin32
   alias DnsContextHandle = LibC::IntPtrT
 

--- a/src/win32cr/networkmanagement/internetconnectionwizard.cr
+++ b/src/win32cr/networkmanagement/internetconnectionwizard.cr
@@ -1,8 +1,15 @@
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   ICW_MAX_ACCTNAME = 256_u32
   ICW_MAX_PASSWORD = 256_u32

--- a/src/win32cr/networkmanagement/iphelper.cr
+++ b/src/win32cr/networkmanagement/iphelper.cr
@@ -4,10 +4,18 @@ require "../networking/winsock.cr"
 require "../system/windowsprogramming.cr"
 require "../system/io.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:iphlpapi.dll")]
+{% else %}
+@[Link("iphlpapi")]
+{% end %}
 lib LibWin32
   alias IcmpHandle = LibC::IntPtrT
   alias HIFTIMESTAMPCHANGE = LibC::IntPtrT

--- a/src/win32cr/networkmanagement/mobilebroadband.cr
+++ b/src/win32cr/networkmanagement/mobilebroadband.cr
@@ -1,9 +1,16 @@
 require "../system/com.cr"
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   MbnConnectionProfileManager = LibC::GUID.new(0xbdfee05a_u32, 0x4418_u16, 0x11dd_u16, StaticArray[0x90_u8, 0xed_u8, 0x0_u8, 0x1c_u8, 0x25_u8, 0x7c_u8, 0xcf_u8, 0xf1_u8])
   MbnInterfaceManager = LibC::GUID.new(0xbdfee05b_u32, 0x4418_u16, 0x11dd_u16, StaticArray[0x90_u8, 0xed_u8, 0x0_u8, 0x1c_u8, 0x25_u8, 0x7c_u8, 0xcf_u8, 0xf1_u8])

--- a/src/win32cr/networkmanagement/multicast.cr
+++ b/src/win32cr/networkmanagement/multicast.cr
@@ -1,9 +1,17 @@
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:dhcpcsvc.dll")]
+{% else %}
+@[Link("dhcpcsvc")]
+{% end %}
 lib LibWin32
   MCAST_CLIENT_ID_LEN = 17_u32
   MCAST_API_CURRENT_VERSION = 1_i32

--- a/src/win32cr/networkmanagement/ndis.cr
+++ b/src/win32cr/networkmanagement/ndis.cr
@@ -4,9 +4,16 @@ require "../networkmanagement/wifi.cr"
 require "../security/extensibleauthenticationprotocol.cr"
 require "../system/remotedesktop.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   IOCTL_NDIS_RESERVED5 = 1507380_u32
   IOCTL_NDIS_RESERVED6 = 1540152_u32

--- a/src/win32cr/networkmanagement/netbios.cr
+++ b/src/win32cr/networkmanagement/netbios.cr
@@ -1,9 +1,17 @@
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:netapi32.dll")]
+{% else %}
+@[Link("netapi32")]
+{% end %}
 lib LibWin32
   NCBNAMSZ = 16_u32
   MAX_LANA = 254_u32

--- a/src/win32cr/networkmanagement/netmanagement.cr
+++ b/src/win32cr/networkmanagement/netmanagement.cr
@@ -5,12 +5,22 @@ require "../system/com.cr"
 require "../system/registry.cr"
 require "../data/xml/msxml.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:netapi32.dll")]
 @[Link(ldflags: "/DELAYLOAD:mstask.dll")]
 @[Link(ldflags: "/DELAYLOAD:rtutils.dll")]
+{% else %}
+@[Link("netapi32")]
+@[Link("mstask")]
+@[Link("rtutils")]
+{% end %}
 lib LibWin32
   NERR_BASE = 2100_u32
   NERR_PasswordExpired = 2242_u32

--- a/src/win32cr/networkmanagement/netshell.cr
+++ b/src/win32cr/networkmanagement/netshell.cr
@@ -1,9 +1,17 @@
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:netsh.dll")]
+{% else %}
+@[Link("netsh")]
+{% end %}
 lib LibWin32
   NETSH_ERROR_BASE = 15000_u32
   ERROR_NO_ENTRIES = 15000_u32

--- a/src/win32cr/networkmanagement/networkdiagnosticsframework.cr
+++ b/src/win32cr/networkmanagement/networkdiagnosticsframework.cr
@@ -3,10 +3,18 @@ require "../system/com.cr"
 require "../networking/winsock.cr"
 require "../security.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:ndfapi.dll")]
+{% else %}
+@[Link("ndfapi")]
+{% end %}
 lib LibWin32
   NDF_ERROR_START = 63744_u32
   NDF_E_LENGTH_EXCEEDED = -2146895616_i32

--- a/src/win32cr/networkmanagement/networkpolicyserver.cr
+++ b/src/win32cr/networkmanagement/networkpolicyserver.cr
@@ -1,9 +1,16 @@
 require "../system/com.cr"
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   RADIUS_EXTENSION_VERSION = 1_u32
   SdoMachine = LibC::GUID.new(0xe9218ae7_u32, 0x9e91_u16, 0x11d1_u16, StaticArray[0xbf_u8, 0x60_u8, 0x0_u8, 0x80_u8, 0xc7_u8, 0x84_u8, 0x6b_u8, 0xc0_u8])

--- a/src/win32cr/networkmanagement/p2p.cr
+++ b/src/win32cr/networkmanagement/p2p.cr
@@ -4,15 +4,28 @@ require "../system/com.cr"
 require "../security/cryptography.cr"
 require "../system/io.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:p2pgraph.dll")]
 @[Link(ldflags: "/DELAYLOAD:p2p.dll")]
 @[Link(ldflags: "/DELAYLOAD:drtprov.dll")]
 @[Link(ldflags: "/DELAYLOAD:drttransport.dll")]
 @[Link(ldflags: "/DELAYLOAD:drt.dll")]
 @[Link(ldflags: "/DELAYLOAD:peerdist.dll")]
+{% else %}
+@[Link("p2pgraph")]
+@[Link("p2p")]
+@[Link("drtprov")]
+@[Link("drttransport")]
+@[Link("drt")]
+@[Link("peerdist")]
+{% end %}
 lib LibWin32
   NS_PNRPNAME = 38_u32
   NS_PNRPCLOUD = 39_u32

--- a/src/win32cr/networkmanagement/qos.cr
+++ b/src/win32cr/networkmanagement/qos.cr
@@ -3,11 +3,20 @@ require "../foundation.cr"
 require "../networkmanagement/ndis.cr"
 require "../system/io.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:qwave.dll")]
 @[Link(ldflags: "/DELAYLOAD:traffic.dll")]
+{% else %}
+@[Link("qwave")]
+@[Link("traffic")]
+{% end %}
 lib LibWin32
   alias LPM_HANDLE = LibC::IntPtrT
   alias RHANDLE = LibC::IntPtrT

--- a/src/win32cr/networkmanagement/rras.cr
+++ b/src/win32cr/networkmanagement/rras.cr
@@ -3,13 +3,24 @@ require "../foundation.cr"
 require "../security/cryptography.cr"
 require "../networkmanagement/iphelper.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:rasapi32.dll")]
 @[Link(ldflags: "/DELAYLOAD:rasdlg.dll")]
 @[Link(ldflags: "/DELAYLOAD:mprapi.dll")]
 @[Link(ldflags: "/DELAYLOAD:rtm.dll")]
+{% else %}
+@[Link("rasapi32")]
+@[Link("rasdlg")]
+@[Link("mprapi")]
+@[Link("rtm")]
+{% end %}
 lib LibWin32
   alias HRASCONN = LibC::IntPtrT
 

--- a/src/win32cr/networkmanagement/snmp.cr
+++ b/src/win32cr/networkmanagement/snmp.cr
@@ -1,11 +1,21 @@
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:snmpapi.dll")]
 @[Link(ldflags: "/DELAYLOAD:mgmtapi.dll")]
 @[Link(ldflags: "/DELAYLOAD:wsnmp32.dll")]
+{% else %}
+@[Link("snmpapi")]
+@[Link("mgmtapi")]
+@[Link("wsnmp32")]
+{% end %}
 lib LibWin32
   ASN_UNIVERSAL = 0_u32
   ASN_APPLICATION = 64_u32

--- a/src/win32cr/networkmanagement/webdav.cr
+++ b/src/win32cr/networkmanagement/webdav.cr
@@ -1,10 +1,19 @@
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:netapi32.dll")]
 @[Link(ldflags: "/DELAYLOAD:davclnt.dll")]
+{% else %}
+@[Link("netapi32")]
+@[Link("davclnt")]
+{% end %}
 lib LibWin32
   DAV_AUTHN_SCHEME_BASIC = 1_u32
   DAV_AUTHN_SCHEME_NTLM = 2_u32

--- a/src/win32cr/networkmanagement/wifi.cr
+++ b/src/win32cr/networkmanagement/wifi.cr
@@ -3,11 +3,20 @@ require "../foundation.cr"
 require "../security/extensibleauthenticationprotocol.cr"
 require "../system/com.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:wlanapi.dll")]
 @[Link(ldflags: "/DELAYLOAD:wlanui.dll")]
+{% else %}
+@[Link("wlanapi")]
+@[Link("wlanui")]
+{% end %}
 lib LibWin32
   L2_REASON_CODE_DOT11_AC_BASE = 131072_u32
   L2_REASON_CODE_DOT11_MSM_BASE = 196608_u32

--- a/src/win32cr/networkmanagement/windowsconnectionmanager.cr
+++ b/src/win32cr/networkmanagement/windowsconnectionmanager.cr
@@ -1,10 +1,19 @@
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:wcmapi.dll")]
 @[Link(ldflags: "/DELAYLOAD:ondemandconnroutehelper.dll")]
+{% else %}
+@[Link("wcmapi")]
+@[Link("ondemandconnroutehelper")]
+{% end %}
 lib LibWin32
   WCM_API_VERSION_1_0 = 1_u32
   WCM_API_VERSION = 1_u32

--- a/src/win32cr/networkmanagement/windowsconnectnow.cr
+++ b/src/win32cr/networkmanagement/windowsconnectnow.cr
@@ -1,9 +1,16 @@
 require "../system/com.cr"
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   WCN_E_PEER_NOT_FOUND = -2147206143_i32
   WCN_E_AUTHENTICATION_FAILED = -2147206142_i32

--- a/src/win32cr/networkmanagement/windowsfilteringplatform.cr
+++ b/src/win32cr/networkmanagement/windowsfilteringplatform.cr
@@ -4,10 +4,18 @@ require "../networking/winsock.cr"
 require "../system/kernel.cr"
 require "../system/rpc.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:fwpuclnt.dll")]
+{% else %}
+@[Link("fwpuclnt")]
+{% end %}
 lib LibWin32
   FWPM_NET_EVENT_KEYWORD_INBOUND_MCAST = 1_u32
   FWPM_NET_EVENT_KEYWORD_INBOUND_BCAST = 2_u32

--- a/src/win32cr/networkmanagement/windowsfirewall.cr
+++ b/src/win32cr/networkmanagement/windowsfirewall.cr
@@ -2,10 +2,16 @@ require "../system/com.cr"
 require "../foundation.cr"
 require "../security.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-net-isolation-l1-1-0.dll")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   NETCON_MAX_NAME_LEN = 256_u32
   S_OBJECT_NO_LONGER_VALID = 2_i32

--- a/src/win32cr/networkmanagement/windowsnetworkvirtualization.cr
+++ b/src/win32cr/networkmanagement/windowsnetworkvirtualization.cr
@@ -3,10 +3,18 @@ require "../networkmanagement/windowsfilteringplatform.cr"
 require "../foundation.cr"
 require "../system/io.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:wnvapi.dll")]
+{% else %}
+@[Link("wnvapi")]
+{% end %}
 lib LibWin32
   WNV_API_MAJOR_VERSION_1 = 1_u32
   WNV_API_MINOR_VERSION_0 = 0_u32

--- a/src/win32cr/networkmanagement/wnet.cr
+++ b/src/win32cr/networkmanagement/wnet.cr
@@ -1,11 +1,21 @@
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:mpr.dll")]
 @[Link(ldflags: "/DELAYLOAD:davclnt.dll")]
 @[Link(ldflags: "/DELAYLOAD:ntlanman.dll")]
+{% else %}
+@[Link("mpr")]
+@[Link("davclnt")]
+@[Link("ntlanman")]
+{% end %}
 lib LibWin32
   alias NetEnumHandle = LibC::IntPtrT
 

--- a/src/win32cr/security.cr
+++ b/src/win32cr/security.cr
@@ -1,11 +1,21 @@
 require "./foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:advapi32.dll")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-security-base-l1-2-2.dll")]
+@[Link(ldflags: "/DELAYLOAD:onecore.dll")]
 @[Link(ldflags: "/DELAYLOAD:user32.dll")]
+{% else %}
+@[Link("advapi32")]
+@[Link("onecore")]
+@[Link("user32")]
+{% end %}
 lib LibWin32
   alias HDIAGNOSTIC_DATA_QUERY_SESSION = LibC::IntPtrT
   alias HDIAGNOSTIC_REPORT = LibC::IntPtrT

--- a/src/win32cr/security/applocker.cr
+++ b/src/win32cr/security/applocker.cr
@@ -1,10 +1,18 @@
 require "../foundation.cr"
 require "../security.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:advapi32.dll")]
+{% else %}
+@[Link("advapi32")]
+{% end %}
 lib LibWin32
   SAFER_SCOPEID_MACHINE = 1_u32
   SAFER_SCOPEID_USER = 2_u32

--- a/src/win32cr/security/authentication/identity.cr
+++ b/src/win32cr/security/authentication/identity.cr
@@ -9,9 +9,14 @@ require "../../system/passwordmanagement.cr"
 require "../../system/com.cr"
 require "../../system/windowsprogramming.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:secur32.dll")]
 @[Link(ldflags: "/DELAYLOAD:advapi32.dll")]
 @[Link(ldflags: "/DELAYLOAD:sspicli.dll")]
@@ -21,7 +26,19 @@ require "../../system/windowsprogramming.cr"
 @[Link(ldflags: "/DELAYLOAD:slc.dll")]
 @[Link(ldflags: "/DELAYLOAD:slcext.dll")]
 @[Link(ldflags: "/DELAYLOAD:slwga.dll")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-core-slapi-l1-1-0.dll")]
+@[Link(ldflags: "/DELAYLOAD:clipc.dll")]
+{% else %}
+@[Link("secur32")]
+@[Link("advapi32")]
+@[Link("sspicli")]
+@[Link("credui")]
+@[Link("schannel")]
+@[Link("tokenbinding")]
+@[Link("slc")]
+@[Link("slcext")]
+@[Link("slwga")]
+@[Link("clipc")]
+{% end %}
 lib LibWin32
   alias LsaHandle = LibC::IntPtrT
 

--- a/src/win32cr/security/authentication/identity/provider.cr
+++ b/src/win32cr/security/authentication/identity/provider.cr
@@ -3,9 +3,16 @@ require "../../../foundation.cr"
 require "../../../ui/shell/propertiessystem.cr"
 require "../../../system/com/structuredstorage.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   OID_OAssociatedIdentityProviderObject = "98c5a3dd-db68-4f1a-8d2b-9079cdfeaf61"
   CoClassIdentityStore = LibC::GUID.new(0x30d49246_u32, 0xd217_u16, 0x465f_u16, StaticArray[0xb0_u8, 0xb_u8, 0xac_u8, 0x9d_u8, 0xdd_u8, 0x65_u8, 0x2e_u8, 0xb7_u8])

--- a/src/win32cr/security/authorization.cr
+++ b/src/win32cr/security/authorization.cr
@@ -3,11 +3,20 @@ require "../foundation.cr"
 require "../system/com.cr"
 require "../system/threading.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:authz.dll")]
 @[Link(ldflags: "/DELAYLOAD:advapi32.dll")]
+{% else %}
+@[Link("authz")]
+@[Link("advapi32")]
+{% end %}
 lib LibWin32
   alias AUTHZ_ACCESS_CHECK_RESULTS_HANDLE = LibC::IntPtrT
   alias AUTHZ_CLIENT_CONTEXT_HANDLE = LibC::IntPtrT

--- a/src/win32cr/security/authorization/ui.cr
+++ b/src/win32cr/security/authorization/ui.cr
@@ -4,10 +4,18 @@ require "../../system/com.cr"
 require "../../ui/controls.cr"
 require "../../security/authorization.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:aclui.dll")]
+{% else %}
+@[Link("aclui")]
+{% end %}
 lib LibWin32
   SI_EDIT_PERMS = 0_i32
   SI_EDIT_OWNER = 1_i32

--- a/src/win32cr/security/configurationsnapin.cr
+++ b/src/win32cr/security/configurationsnapin.cr
@@ -1,9 +1,16 @@
 require "../foundation.cr"
 require "../system/com.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   Cnodetypescetemplateservices = "24a7f717-1f0c-11d1-affb-00c04fb984f9"
   Cnodetypesceanalysisservices = "678050c7-1ff8-11d1-affb-00c04fb984f9"

--- a/src/win32cr/security/credentials.cr
+++ b/src/win32cr/security/credentials.cr
@@ -2,14 +2,26 @@ require "../foundation.cr"
 require "../graphics/gdi.cr"
 require "../ui/windowsandmessaging.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:keycredmgr.dll")]
 @[Link(ldflags: "/DELAYLOAD:advapi32.dll")]
 @[Link(ldflags: "/DELAYLOAD:credui.dll")]
 @[Link(ldflags: "/DELAYLOAD:winscard.dll")]
 @[Link(ldflags: "/DELAYLOAD:scarddlg.dll")]
+{% else %}
+@[Link("keycredmgr")]
+@[Link("advapi32")]
+@[Link("credui")]
+@[Link("winscard")]
+@[Link("scarddlg")]
+{% end %}
 lib LibWin32
   FILE_DEVICE_SMARTCARD = 49_u32
   GUID_DEVINTERFACE_SMARTCARD_READER = "50dd5230-ba8a-11d1-bf5d-0000f805f530"

--- a/src/win32cr/security/cryptography.cr
+++ b/src/win32cr/security/cryptography.cr
@@ -3,9 +3,14 @@ require "../system/registry.cr"
 require "../security.cr"
 require "../system/com.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:advapi32.dll")]
 @[Link(ldflags: "/DELAYLOAD:bcrypt.dll")]
 @[Link(ldflags: "/DELAYLOAD:ncrypt.dll")]
@@ -14,6 +19,16 @@ require "../system/com.cr"
 @[Link(ldflags: "/DELAYLOAD:cryptnet.dll")]
 @[Link(ldflags: "/DELAYLOAD:cryptxml.dll")]
 @[Link(ldflags: "/DELAYLOAD:infocardapi.dll")]
+{% else %}
+@[Link("advapi32")]
+@[Link("bcrypt")]
+@[Link("ncrypt")]
+@[Link("crypt32")]
+@[Link("wintrust")]
+@[Link("cryptnet")]
+@[Link("cryptxml")]
+@[Link("infocardapi")]
+{% end %}
 lib LibWin32
   alias HCRYPTASYNC = LibC::IntPtrT
   alias HCERTCHAINENGINE = LibC::IntPtrT

--- a/src/win32cr/security/cryptography/catalog.cr
+++ b/src/win32cr/security/cryptography/catalog.cr
@@ -2,10 +2,18 @@ require "../../foundation.cr"
 require "../../security/cryptography/sip.cr"
 require "../../security/cryptography.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:wintrust.dll")]
+{% else %}
+@[Link("wintrust")]
+{% end %}
 lib LibWin32
   CRYPTCAT_MAX_MEMBERTAG = 64_u32
   CRYPTCAT_MEMBER_SORTED = 1073741824_u32

--- a/src/win32cr/security/cryptography/certificates.cr
+++ b/src/win32cr/security/cryptography/certificates.cr
@@ -3,11 +3,20 @@ require "../../foundation.cr"
 require "../../security/cryptography.cr"
 require "../../security/authentication/identity.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:certadm.dll")]
 @[Link(ldflags: "/DELAYLOAD:certpoleng.dll")]
+{% else %}
+@[Link("certadm")]
+@[Link("certpoleng")]
+{% end %}
 lib LibWin32
   CA_DISP_INCOMPLETE = 0_u32
   CA_DISP_ERROR = 1_u32

--- a/src/win32cr/security/cryptography/sip.cr
+++ b/src/win32cr/security/cryptography/sip.cr
@@ -2,11 +2,20 @@ require "../../foundation.cr"
 require "../../security/cryptography.cr"
 require "../../security/cryptography/catalog.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:wintrust.dll")]
 @[Link(ldflags: "/DELAYLOAD:crypt32.dll")]
+{% else %}
+@[Link("wintrust")]
+@[Link("crypt32")]
+{% end %}
 lib LibWin32
   MSSIP_FLAGS_PROHIBIT_RESIZE_ON_CREATE = 65536_u32
   MSSIP_FLAGS_USE_CATALOG = 131072_u32

--- a/src/win32cr/security/cryptography/ui.cr
+++ b/src/win32cr/security/cryptography/ui.cr
@@ -3,10 +3,18 @@ require "../../security/cryptography.cr"
 require "../../ui/controls.cr"
 require "../../security/wintrust.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:cryptui.dll")]
+{% else %}
+@[Link("cryptui")]
+{% end %}
 lib LibWin32
   CRYTPDLG_FLAGS_MASK = 4278190080_u32
   CRYPTDLG_REVOCATION_DEFAULT = 0_u32

--- a/src/win32cr/security/diagnosticdataquery.cr
+++ b/src/win32cr/security/diagnosticdataquery.cr
@@ -1,10 +1,18 @@
 require "../foundation.cr"
 require "../security.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:diagnosticdataquery.dll")]
+{% else %}
+@[Link("diagnosticdataquery")]
+{% end %}
 lib LibWin32
 
   enum DdqAccessLevel : Int32

--- a/src/win32cr/security/directoryservices.cr
+++ b/src/win32cr/security/directoryservices.cr
@@ -3,10 +3,18 @@ require "../security.cr"
 require "../security/authorization/ui.cr"
 require "../ui/controls.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:dssec.dll")]
+{% else %}
+@[Link("dssec")]
+{% end %}
 lib LibWin32
   DSSI_READ_ONLY = 1_u32
   DSSI_NO_ACCESS_CHECK = 2_u32

--- a/src/win32cr/security/enterprisedata.cr
+++ b/src/win32cr/security/enterprisedata.cr
@@ -3,11 +3,20 @@ require "../foundation.cr"
 require "../system/com.cr"
 require "../storage/packaging/appx.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:srpapi.dll")]
 @[Link(ldflags: "/DELAYLOAD:efswrt.dll")]
+{% else %}
+@[Link("srpapi")]
+@[Link("efswrt")]
+{% end %}
 lib LibWin32
 
   enum ENTERPRISE_DATA_POLICIES : UInt32

--- a/src/win32cr/security/extensibleauthenticationprotocol.cr
+++ b/src/win32cr/security/extensibleauthenticationprotocol.cr
@@ -2,11 +2,20 @@ require "../foundation.cr"
 require "../system/com.cr"
 require "../data/xml/msxml.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:eappcfg.dll")]
 @[Link(ldflags: "/DELAYLOAD:eappprxy.dll")]
+{% else %}
+@[Link("eappcfg")]
+@[Link("eappprxy")]
+{% end %}
 lib LibWin32
   FACILITY_EAP_MESSAGE = 2114_u32
   EAP_GROUP_MASK = 65280_i32

--- a/src/win32cr/security/isolation.cr
+++ b/src/win32cr/security/isolation.cr
@@ -3,13 +3,22 @@ require "../system/com.cr"
 require "../security.cr"
 require "../system/registry.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-security-isolatedcontainer-l1-1-1.dll")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-security-isolatedcontainer-l1-1-0.dll")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+@[Link(ldflags: "/DELAYLOAD:shcore.dll")]
 @[Link(ldflags: "/DELAYLOAD:isolatedwindowsenvironmentutils.dll")]
 @[Link(ldflags: "/DELAYLOAD:userenv.dll")]
+{% else %}
+@[Link("shcore")]
+@[Link("isolatedwindowsenvironmentutils")]
+@[Link("userenv")]
+{% end %}
 lib LibWin32
   IsolatedAppLauncher = LibC::GUID.new(0xbc812430_u32, 0xe75e_u16, 0x4fd1_u16, StaticArray[0x96_u8, 0x41_u8, 0x1f_u8, 0x9f_u8, 0x1e_u8, 0x2d_u8, 0x9a_u8, 0x1f_u8])
 

--- a/src/win32cr/security/licenseprotection.cr
+++ b/src/win32cr/security/licenseprotection.cr
@@ -1,9 +1,17 @@
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:licenseprotection.dll")]
+{% else %}
+@[Link("licenseprotection")]
+{% end %}
 lib LibWin32
 
   enum LicenseProtectionStatus : Int32

--- a/src/win32cr/security/networkaccessprotection.cr
+++ b/src/win32cr/security/networkaccessprotection.cr
@@ -1,8 +1,15 @@
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   ComponentTypeEnforcementClientSoH = 1_u32
   ComponentTypeEnforcementClientRp = 2_u32

--- a/src/win32cr/security/tpm.cr
+++ b/src/win32cr/security/tpm.cr
@@ -1,9 +1,16 @@
 require "../system/com.cr"
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   TPMVSC_DEFAULT_ADMIN_ALGORITHM_ID = 130_u32
   TpmVirtualSmartCardManager = LibC::GUID.new(0x16a18e86_u32, 0x7f6e_u16, 0x4c20_u16, StaticArray[0xad_u8, 0x89_u8, 0x4f_u8, 0xfc_u8, 0xd_u8, 0xb7_u8, 0xa9_u8, 0x6a_u8])

--- a/src/win32cr/security/wintrust.cr
+++ b/src/win32cr/security/wintrust.cr
@@ -2,10 +2,18 @@ require "../foundation.cr"
 require "../security/cryptography.cr"
 require "../security/cryptography/sip.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:wintrust.dll")]
+{% else %}
+@[Link("wintrust")]
+{% end %}
 lib LibWin32
   WINTRUST_MAX_HEADER_BYTES_TO_MAP_DEFAULT = 10485760_u32
   WINTRUST_MAX_HASH_BYTES_TO_MAP_DEFAULT = 1048576_u32

--- a/src/win32cr/security/winwlx.cr
+++ b/src/win32cr/security/winwlx.cr
@@ -3,9 +3,16 @@ require "../security.cr"
 require "../system/stationsanddesktops.cr"
 require "../ui/windowsandmessaging.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   WLX_VERSION_1_0 = 65536_u32
   WLX_VERSION_1_1 = 65537_u32

--- a/src/win32cr/storage/cabinets.cr
+++ b/src/win32cr/storage/cabinets.cr
@@ -1,9 +1,17 @@
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:cabinet.dll")]
+{% else %}
+@[Link("cabinet")]
+{% end %}
 lib LibWin32
   INCLUDED_FCI = 1_u32
   A_NAME_IS_UTF = 128_u32

--- a/src/win32cr/storage/cloudfilters.cr
+++ b/src/win32cr/storage/cloudfilters.cr
@@ -3,10 +3,18 @@ require "../foundation.cr"
 require "../system/correlationvector.cr"
 require "../system/io.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:cldapi.dll")]
+{% else %}
+@[Link("cldapi")]
+{% end %}
 lib LibWin32
   alias CF_CONNECTION_KEY = LibC::IntPtrT
 

--- a/src/win32cr/storage/compression.cr
+++ b/src/win32cr/storage/compression.cr
@@ -1,9 +1,17 @@
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:cabinet.dll")]
+{% else %}
+@[Link("cabinet")]
+{% end %}
 lib LibWin32
   alias COMPRESSOR_HANDLE = LibC::IntPtrT
 

--- a/src/win32cr/storage/datadeduplication.cr
+++ b/src/win32cr/storage/datadeduplication.cr
@@ -1,9 +1,16 @@
 require "../system/com.cr"
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   DEDUP_CHUNKLIB_MAX_CHUNKS_ENUM = 1024_u32
   DedupBackupSupport = LibC::GUID.new(0x73d6b2ad_u32, 0x2984_u16, 0x4715_u16, StaticArray[0xb2_u8, 0xe3_u8, 0x92_u8, 0x4c_u8, 0x14_u8, 0x97_u8, 0x44_u8, 0xdd_u8])

--- a/src/win32cr/storage/distributedfilesystem.cr
+++ b/src/win32cr/storage/distributedfilesystem.cr
@@ -1,10 +1,18 @@
 require "../foundation.cr"
 require "../security.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:netapi32.dll")]
+{% else %}
+@[Link("netapi32")]
+{% end %}
 lib LibWin32
   FSCTL_DFS_BASE = 6_u32
   DFS_VOLUME_STATES = 15_u32

--- a/src/win32cr/storage/enhancedstorage.cr
+++ b/src/win32cr/storage/enhancedstorage.cr
@@ -2,9 +2,16 @@ require "../foundation.cr"
 require "../system/com.cr"
 require "../devices/portabledevices.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   GUID_DEVINTERFACE_ENHANCED_STORAGE_SILO = "3897f6a4-fd35-4bc8-a0b7-5dbba36adafa"
   WPD_CATEGORY_ENHANCED_STORAGE = "91248166-b832-4ad4-baa4-7ca0b6b2798c"

--- a/src/win32cr/storage/filehistory.cr
+++ b/src/win32cr/storage/filehistory.cr
@@ -2,10 +2,18 @@ require "../system/com.cr"
 require "../foundation.cr"
 require "../system/windowsprogramming.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:fhsvcctl.dll")]
+{% else %}
+@[Link("fhsvcctl")]
+{% end %}
 lib LibWin32
   FHCFG_E_CORRUPT_CONFIG_FILE = -2147220736_i32
   FHCFG_E_CONFIG_FILE_NOT_FOUND = -2147220735_i32

--- a/src/win32cr/storage/fileserverresourcemanager.cr
+++ b/src/win32cr/storage/fileserverresourcemanager.cr
@@ -1,9 +1,16 @@
 require "../system/com.cr"
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   FSRM_DISPID_FEATURE_MASK = 251658240_u32
   FSRM_DISPID_INTERFACE_A_MASK = 15728640_u32

--- a/src/win32cr/storage/filesystem.cr
+++ b/src/win32cr/storage/filesystem.cr
@@ -4,10 +4,15 @@ require "../system/com.cr"
 require "../system/io.cr"
 require "../system/windowsprogramming.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-core-file-fromapp-l1-1-0.dll")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+@[Link(ldflags: "/DELAYLOAD:onecoreuap.dll")]
 @[Link(ldflags: "/DELAYLOAD:version.dll")]
 @[Link(ldflags: "/DELAYLOAD:clfsw32.dll")]
 @[Link(ldflags: "/DELAYLOAD:advapi32.dll")]
@@ -15,7 +20,16 @@ require "../system/windowsprogramming.cr"
 @[Link(ldflags: "/DELAYLOAD:txfw32.dll")]
 @[Link(ldflags: "/DELAYLOAD:ktmw32.dll")]
 @[Link(ldflags: "/DELAYLOAD:netapi32.dll")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-core-ioring-l1-1-0.dll")]
+{% else %}
+@[Link("onecoreuap")]
+@[Link("version")]
+@[Link("clfsw32")]
+@[Link("advapi32")]
+@[Link("wofutil")]
+@[Link("txfw32")]
+@[Link("ktmw32")]
+@[Link("netapi32")]
+{% end %}
 lib LibWin32
   alias FindFileHandle = LibC::IntPtrT
   alias FindFileNameHandle = LibC::IntPtrT

--- a/src/win32cr/storage/imapi.cr
+++ b/src/win32cr/storage/imapi.cr
@@ -4,10 +4,18 @@ require "../system/ole.cr"
 require "../system/com/structuredstorage.cr"
 require "../system/addressbook.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:mapi32.dll")]
+{% else %}
+@[Link("mapi32")]
+{% end %}
 lib LibWin32
   IMAPI_SECTOR_SIZE = 2048_u32
   IMAPI2_DEFAULT_COMMAND_TIMEOUT = 10_u32

--- a/src/win32cr/storage/indexserver.cr
+++ b/src/win32cr/storage/indexserver.cr
@@ -2,10 +2,18 @@ require "../system/com/structuredstorage.cr"
 require "../system/com.cr"
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:query.dll")]
+{% else %}
+@[Link("query")]
+{% end %}
 lib LibWin32
   CI_VERSION_WDS30 = 258_u32
   CI_VERSION_WDS40 = 265_u32

--- a/src/win32cr/storage/installablefilesystems.cr
+++ b/src/win32cr/storage/installablefilesystems.cr
@@ -2,10 +2,18 @@ require "../foundation.cr"
 require "../security.cr"
 require "../system/io.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:fltlib.dll")]
+{% else %}
+@[Link("fltlib")]
+{% end %}
 lib LibWin32
   alias HFILTER = LibC::IntPtrT
   alias HFILTER_INSTANCE = LibC::IntPtrT

--- a/src/win32cr/storage/iscsidisc.cr
+++ b/src/win32cr/storage/iscsidisc.cr
@@ -1,10 +1,18 @@
 require "../foundation.cr"
 require "../system/ioctl.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:iscsidsc.dll")]
+{% else %}
+@[Link("iscsidsc")]
+{% end %}
 lib LibWin32
   IOCTL_SCSI_BASE = 4_u32
   ScsiRawInterfaceGuid = "53f56309-b6bf-11d0-94f2-00a0c91efb8b"

--- a/src/win32cr/storage/jet.cr
+++ b/src/win32cr/storage/jet.cr
@@ -1,10 +1,18 @@
 require "../storage/structuredstorage.cr"
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:esent.dll")]
+{% else %}
+@[Link("esent")]
+{% end %}
 lib LibWin32
   alias JET_OSSNAPID = LibC::UINT_PTR
   alias JET_LS = LibC::UINT_PTR

--- a/src/win32cr/storage/offlinefiles.cr
+++ b/src/win32cr/storage/offlinefiles.cr
@@ -1,10 +1,18 @@
 require "../system/com.cr"
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:cscapi.dll")]
+{% else %}
+@[Link("cscapi")]
+{% end %}
 lib LibWin32
   OFFLINEFILES_SYNC_STATE_LOCAL_KNOWN = 1_u32
   OFFLINEFILES_SYNC_STATE_REMOTE_KNOWN = 2_u32

--- a/src/win32cr/storage/operationrecorder.cr
+++ b/src/win32cr/storage/operationrecorder.cr
@@ -1,9 +1,17 @@
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:advapi32.dll")]
+{% else %}
+@[Link("advapi32")]
+{% end %}
 lib LibWin32
 
   enum OPERATION_START_FLAGS : UInt32

--- a/src/win32cr/storage/packaging/appx.cr
+++ b/src/win32cr/storage/packaging/appx.cr
@@ -1,11 +1,18 @@
 require "../../foundation.cr"
 require "../../system/com.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-appmodel-runtime-l1-1-1.dll")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-appmodel-runtime-l1-1-3.dll")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+@[Link(ldflags: "/DELAYLOAD:kernel.appcore.dll")]
+{% else %}
+@[Link("kernel.appcore")]
+{% end %}
 lib LibWin32
   PACKAGE_PROPERTY_FRAMEWORK = 1_u32
   PACKAGE_PROPERTY_RESOURCE = 2_u32

--- a/src/win32cr/storage/packaging/opc.cr
+++ b/src/win32cr/storage/packaging/opc.cr
@@ -3,9 +3,16 @@ require "../../foundation.cr"
 require "../../security/cryptography.cr"
 require "../../security.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   OPC_E_NONCONFORMING_URI = -2142175231_i32
   OPC_E_RELATIVE_URI_REQUIRED = -2142175230_i32

--- a/src/win32cr/storage/projectedfilesystem.cr
+++ b/src/win32cr/storage/projectedfilesystem.cr
@@ -1,9 +1,17 @@
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:projectedfslib.dll")]
+{% else %}
+@[Link("projectedfslib")]
+{% end %}
 lib LibWin32
   alias PRJ_NAMESPACE_VIRTUALIZATION_CONTEXT = LibC::IntPtrT
   alias PRJ_DIR_ENTRY_BUFFER_HANDLE = LibC::IntPtrT

--- a/src/win32cr/storage/structuredstorage.cr
+++ b/src/win32cr/storage/structuredstorage.cr
@@ -1,6 +1,13 @@
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   alias JET_HANDLE = LibC::UINT_PTR
   alias JET_INSTANCE = LibC::UINT_PTR

--- a/src/win32cr/storage/vhd.cr
+++ b/src/win32cr/storage/vhd.cr
@@ -2,10 +2,18 @@ require "../foundation.cr"
 require "../security.cr"
 require "../system/io.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:virtdisk.dll")]
+{% else %}
+@[Link("virtdisk")]
+{% end %}
 lib LibWin32
   VIRTUAL_STORAGE_TYPE_VENDOR_UNKNOWN = "00000000-0000-0000-0000-000000000000"
   VIRTUAL_STORAGE_TYPE_VENDOR_MICROSOFT = "ec984aec-a0f9-47e9-901f-71415a66345b"

--- a/src/win32cr/storage/virtualdiskservice.cr
+++ b/src/win32cr/storage/virtualdiskservice.cr
@@ -1,9 +1,16 @@
 require "../foundation.cr"
 require "../system/com.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   VDS_NF_VOLUME_ARRIVE = 4_u32
   VDS_NF_VOLUME_DEPART = 5_u32

--- a/src/win32cr/storage/vss.cr
+++ b/src/win32cr/storage/vss.cr
@@ -3,10 +3,18 @@ require "../foundation.cr"
 require "../data/xml/msxml.cr"
 require "../storage/virtualdiskservice.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:vssapi.dll")]
+{% else %}
+@[Link("vssapi")]
+{% end %}
 lib LibWin32
   VSS_ASSOC_NO_MAX_SPACE = -1_i32
   VSS_ASSOC_REMOVE = 0_u32

--- a/src/win32cr/storage/xps.cr
+++ b/src/win32cr/storage/xps.cr
@@ -5,12 +5,22 @@ require "../storage/packaging/opc.cr"
 require "../security.cr"
 require "../security/cryptography.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:winspool.dll")]
 @[Link(ldflags: "/DELAYLOAD:gdi32.dll")]
 @[Link(ldflags: "/DELAYLOAD:user32.dll")]
+{% else %}
+@[Link("winspool")]
+@[Link("gdi32")]
+@[Link("user32")]
+{% end %}
 lib LibWin32
   alias HPTPROVIDER = LibC::IntPtrT
 

--- a/src/win32cr/storage/xps/printing.cr
+++ b/src/win32cr/storage/xps/printing.cr
@@ -2,10 +2,18 @@ require "../../foundation.cr"
 require "../../system/com.cr"
 require "../../storage/xps.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:xpsprint.dll")]
+{% else %}
+@[Link("xpsprint")]
+{% end %}
 lib LibWin32
   ID_DOCUMENTPACKAGETARGET_MSXPS = "9cae40a8-ded1-41c9-a9fd-d735ef33aeda"
   ID_DOCUMENTPACKAGETARGET_OPENXPS = "0056bb72-8c9c-4612-bd0f-93012a87099d"

--- a/src/win32cr/system/addressbook.cr
+++ b/src/win32cr/system/addressbook.cr
@@ -2,11 +2,20 @@ require "../foundation.cr"
 require "../system/com.cr"
 require "../system/com/structuredstorage.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:rtm.dll")]
 @[Link(ldflags: "/DELAYLOAD:mapi32.dll")]
+{% else %}
+@[Link("rtm")]
+@[Link("mapi32")]
+{% end %}
 lib LibWin32
   PROP_ID_SECURE_MIN = 26608_u32
   PROP_ID_SECURE_MAX = 26623_u32

--- a/src/win32cr/system/antimalware.cr
+++ b/src/win32cr/system/antimalware.cr
@@ -1,10 +1,18 @@
 require "../foundation.cr"
 require "../system/com.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:amsi.dll")]
+{% else %}
+@[Link("amsi")]
+{% end %}
 lib LibWin32
   alias HAMSICONTEXT = LibC::IntPtrT
   alias HAMSISESSION = LibC::IntPtrT

--- a/src/win32cr/system/applicationinstallationandservicing.cr
+++ b/src/win32cr/system/applicationinstallationandservicing.cr
@@ -4,14 +4,26 @@ require "../system/windowsprogramming.cr"
 require "../system/registry.cr"
 require "../security/cryptography.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:msi.dll")]
 @[Link(ldflags: "/DELAYLOAD:sfc.dll")]
 @[Link(ldflags: "/DELAYLOAD:mspatchc.dll")]
 @[Link(ldflags: "/DELAYLOAD:mspatcha.dll")]
 @[Link(ldflags: "/DELAYLOAD:msdelta.dll")]
+{% else %}
+@[Link("msi")]
+@[Link("sfc")]
+@[Link("mspatchc")]
+@[Link("mspatcha")]
+@[Link("msdelta")]
+{% end %}
 lib LibWin32
   alias MSIHANDLE = UInt32
 

--- a/src/win32cr/system/applicationverifier.cr
+++ b/src/win32cr/system/applicationverifier.cr
@@ -1,9 +1,17 @@
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:verifier.dll")]
+{% else %}
+@[Link("verifier")]
+{% end %}
 lib LibWin32
   AVRF_MAX_TRACES = 32_u32
 

--- a/src/win32cr/system/assessmenttool.cr
+++ b/src/win32cr/system/assessmenttool.cr
@@ -4,9 +4,16 @@ require "../data/xml/msxml.cr"
 require "../graphics/gdi.cr"
 require "../ui/accessibility.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   CInitiateWinSAT = LibC::GUID.new(0x489331dc_u32, 0xf5e0_u16, 0x4528_u16, StaticArray[0x9f_u8, 0xda_u8, 0x45_u8, 0x33_u8, 0x1b_u8, 0xf4_u8, 0xa5_u8, 0x71_u8])
   CQueryWinSAT = LibC::GUID.new(0xf3bdfad3_u32, 0xf276_u16, 0x49e9_u16, StaticArray[0x9b_u8, 0x17_u8, 0xc4_u8, 0x74_u8, 0xf4_u8, 0x8f_u8, 0x7_u8, 0x64_u8])

--- a/src/win32cr/system/com.cr
+++ b/src/win32cr/system/com.cr
@@ -5,12 +5,22 @@ require "../system/systemservices.cr"
 require "../security.cr"
 require "../system/ole.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:ole32.dll")]
 @[Link(ldflags: "/DELAYLOAD:urlmon.dll")]
 @[Link(ldflags: "/DELAYLOAD:oleaut32.dll")]
+{% else %}
+@[Link("ole32")]
+@[Link("urlmon")]
+@[Link("oleaut32")]
+{% end %}
 lib LibWin32
   alias CO_MTA_USAGE_COOKIE = LibC::IntPtrT
   alias CO_DEVICE_CATALOG_COOKIE = LibC::IntPtrT

--- a/src/win32cr/system/com/callobj.cr
+++ b/src/win32cr/system/com/callobj.cr
@@ -1,10 +1,18 @@
 require "../../foundation.cr"
 require "../../system/com.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:ole32.dll")]
+{% else %}
+@[Link("ole32")]
+{% end %}
 lib LibWin32
 
   enum CALLFRAME_COPY : Int32

--- a/src/win32cr/system/com/channelcredentials.cr
+++ b/src/win32cr/system/com/channelcredentials.cr
@@ -1,9 +1,16 @@
 require "../../system/com.cr"
 require "../../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
 
   struct IChannelCredentialsVTbl

--- a/src/win32cr/system/com/events.cr
+++ b/src/win32cr/system/com/events.cr
@@ -1,9 +1,16 @@
 require "../../system/com.cr"
 require "../../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   CEventSystem = LibC::GUID.new(0x4e14fba2_u32, 0x2e22_u16, 0x11d1_u16, StaticArray[0x99_u8, 0x64_u8, 0x0_u8, 0xc0_u8, 0x4f_u8, 0xbb_u8, 0xb3_u8, 0x45_u8])
   CEventPublisher = LibC::GUID.new(0xab944620_u32, 0x79c6_u16, 0x11d1_u16, StaticArray[0x88_u8, 0xf9_u8, 0x0_u8, 0x80_u8, 0xc7_u8, 0xd7_u8, 0x71_u8, 0xbf_u8])

--- a/src/win32cr/system/com/marshal.cr
+++ b/src/win32cr/system/com/marshal.cr
@@ -3,11 +3,20 @@ require "../../foundation.cr"
 require "../../graphics/gdi.cr"
 require "../../ui/windowsandmessaging.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:oleaut32.dll")]
 @[Link(ldflags: "/DELAYLOAD:ole32.dll")]
+{% else %}
+@[Link("oleaut32")]
+@[Link("ole32")]
+{% end %}
 lib LibWin32
 
   enum STDMSHLFLAGS : Int32

--- a/src/win32cr/system/com/structuredstorage.cr
+++ b/src/win32cr/system/com/structuredstorage.cr
@@ -2,12 +2,22 @@ require "../../system/com.cr"
 require "../../foundation.cr"
 require "../../security.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:ole32.dll")]
 @[Link(ldflags: "/DELAYLOAD:dflayout.dll")]
 @[Link(ldflags: "/DELAYLOAD:propsys.dll")]
+{% else %}
+@[Link("ole32")]
+@[Link("dflayout")]
+@[Link("propsys")]
+{% end %}
 lib LibWin32
   PROPSETFLAG_DEFAULT = 0_u32
   PROPSETFLAG_NONSIMPLE = 1_u32

--- a/src/win32cr/system/com/ui.cr
+++ b/src/win32cr/system/com/ui.cr
@@ -4,9 +4,16 @@ require "../../system/com/structuredstorage.cr"
 require "../../graphics/gdi.cr"
 require "../../ui/windowsandmessaging.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
 
   struct IThumbnailExtractorVTbl

--- a/src/win32cr/system/com/urlmon.cr
+++ b/src/win32cr/system/com/urlmon.cr
@@ -2,10 +2,18 @@ require "../../system/com.cr"
 require "../../foundation.cr"
 require "../../data/xml/msxml.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:urlmon.dll")]
+{% else %}
+@[Link("urlmon")]
+{% end %}
 lib LibWin32
   MKSYS_URLMONIKER = 6_u32
   URL_MK_LEGACY = 0_u32

--- a/src/win32cr/system/componentservices.cr
+++ b/src/win32cr/system/componentservices.cr
@@ -2,12 +2,22 @@ require "../system/com.cr"
 require "../foundation.cr"
 require "../system/distributedtransactioncoordinator.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:ole32.dll")]
 @[Link(ldflags: "/DELAYLOAD:comsvcs.dll")]
 @[Link(ldflags: "/DELAYLOAD:mtxdm.dll")]
+{% else %}
+@[Link("ole32")]
+@[Link("comsvcs")]
+@[Link("mtxdm")]
+{% end %}
 lib LibWin32
   GUID_STRING_SIZE = 40_u32
   DATA_NOT_AVAILABLE = 4294967295_u32

--- a/src/win32cr/system/console.cr
+++ b/src/win32cr/system/console.cr
@@ -1,9 +1,16 @@
 require "../foundation.cr"
 require "../security.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   alias HPCON = LibC::IntPtrT
 

--- a/src/win32cr/system/contacts.cr
+++ b/src/win32cr/system/contacts.cr
@@ -1,9 +1,16 @@
 require "../system/com.cr"
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   CGD_DEFAULT = 0_u32
   CGD_UNKNOWN_PROPERTY = 0_u32

--- a/src/win32cr/system/correlationvector.cr
+++ b/src/win32cr/system/correlationvector.cr
@@ -1,8 +1,15 @@
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   RTL_CORRELATION_VECTOR_STRING_LENGTH = 129_u32
   RTL_CORRELATION_VECTOR_V1_PREFIX_LENGTH = 16_u32

--- a/src/win32cr/system/dataexchange.cr
+++ b/src/win32cr/system/dataexchange.cr
@@ -2,11 +2,20 @@ require "../security.cr"
 require "../foundation.cr"
 require "../graphics/gdi.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:user32.dll")]
 @[Link(ldflags: "/DELAYLOAD:gdi32.dll")]
+{% else %}
+@[Link("user32")]
+@[Link("gdi32")]
+{% end %}
 lib LibWin32
   alias HSZ = LibC::IntPtrT
   alias HCONV = LibC::IntPtrT

--- a/src/win32cr/system/deploymentservices.cr
+++ b/src/win32cr/system/deploymentservices.cr
@@ -2,14 +2,26 @@ require "../foundation.cr"
 require "../system/registry.cr"
 require "../system/com.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:wdsclientapi.dll")]
 @[Link(ldflags: "/DELAYLOAD:wdspxe.dll")]
 @[Link(ldflags: "/DELAYLOAD:wdsmc.dll")]
 @[Link(ldflags: "/DELAYLOAD:wdstptc.dll")]
 @[Link(ldflags: "/DELAYLOAD:wdsbp.dll")]
+{% else %}
+@[Link("wdsclientapi")]
+@[Link("wdspxe")]
+@[Link("wdsmc")]
+@[Link("wdstptc")]
+@[Link("wdsbp")]
+{% end %}
 lib LibWin32
   WDS_CLI_TRANSFER_ASYNCHRONOUS = 1_u32
   WDS_CLI_NO_SPARSE_FILE = 2_u32

--- a/src/win32cr/system/desktopsharing.cr
+++ b/src/win32cr/system/desktopsharing.cr
@@ -1,9 +1,16 @@
 require "../system/com.cr"
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   DISPID_RDPSRAPI_METHOD_OPEN = 100_u32
   DISPID_RDPSRAPI_METHOD_CLOSE = 101_u32

--- a/src/win32cr/system/developerlicensing.cr
+++ b/src/win32cr/system/developerlicensing.cr
@@ -1,9 +1,17 @@
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:wsclient.dll")]
+{% else %}
+@[Link("wsclient")]
+{% end %}
 lib LibWin32
 
   # Params # pexpiration : FILETIME* [In]

--- a/src/win32cr/system/diagnostics/ceip.cr
+++ b/src/win32cr/system/diagnostics/ceip.cr
@@ -1,8 +1,15 @@
 require "../../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
 
   # Params # 

--- a/src/win32cr/system/diagnostics/debug.cr
+++ b/src/win32cr/system/diagnostics/debug.cr
@@ -9,17 +9,30 @@ require "../../system/com/structuredstorage.cr"
 require "../../system/ole.cr"
 require "../../security/wintrust.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:dbgeng.dll")]
 @[Link(ldflags: "/DELAYLOAD:dbgmodel.dll")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-core-util-l1-1-1.dll")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-core-errorhandling-l1-1-3.dll")]
+@[Link(ldflags: "/DELAYLOAD:onecore.dll")]
 @[Link(ldflags: "/DELAYLOAD:advapi32.dll")]
 @[Link(ldflags: "/DELAYLOAD:dbghelp.dll")]
 @[Link(ldflags: "/DELAYLOAD:imagehlp.dll")]
 @[Link(ldflags: "/DELAYLOAD:user32.dll")]
+{% else %}
+@[Link("dbgeng")]
+@[Link("dbgmodel")]
+@[Link("onecore")]
+@[Link("advapi32")]
+@[Link("dbghelp")]
+@[Link("imagehlp")]
+@[Link("user32")]
+{% end %}
 lib LibWin32
   WOW64_CONTEXT_i386 = 65536_u32
   WOW64_CONTEXT_i486 = 65536_u32

--- a/src/win32cr/system/diagnostics/debug/webapp.cr
+++ b/src/win32cr/system/diagnostics/debug/webapp.cr
@@ -3,9 +3,16 @@ require "../../../foundation.cr"
 require "../../../web/mshtml.cr"
 require "../../../system/diagnostics/debug.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   alias RegisterAuthoringClientFunctionType = Proc(IWebApplicationAuthoringMode, IWebApplicationHost, HRESULT)
   alias UnregisterAuthoringClientFunctionType = Proc(IWebApplicationHost, HRESULT)

--- a/src/win32cr/system/diagnostics/etw.cr
+++ b/src/win32cr/system/diagnostics/etw.cr
@@ -3,11 +3,20 @@ require "../../system/time.cr"
 require "../../system/com.cr"
 require "../../security.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:advapi32.dll")]
 @[Link(ldflags: "/DELAYLOAD:tdh.dll")]
+{% else %}
+@[Link("advapi32")]
+@[Link("tdh")]
+{% end %}
 lib LibWin32
   alias TDH_HANDLE = LibC::IntPtrT
 

--- a/src/win32cr/system/diagnostics/processsnapshotting.cr
+++ b/src/win32cr/system/diagnostics/processsnapshotting.cr
@@ -2,9 +2,16 @@ require "../../foundation.cr"
 require "../../system/memory.cr"
 require "../../system/diagnostics/debug.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   alias HPSS = LibC::IntPtrT
   alias HPSSWALK = LibC::IntPtrT

--- a/src/win32cr/system/diagnostics/toolhelp.cr
+++ b/src/win32cr/system/diagnostics/toolhelp.cr
@@ -1,8 +1,15 @@
 require "../../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   MAX_MODULE_NAME32 = 255_u32
   HF32_DEFAULT = 1_u32

--- a/src/win32cr/system/distributedtransactioncoordinator.cr
+++ b/src/win32cr/system/distributedtransactioncoordinator.cr
@@ -1,10 +1,18 @@
 require "../foundation.cr"
 require "../system/com.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:xolehlp.dll")]
+{% else %}
+@[Link("xolehlp")]
+{% end %}
 lib LibWin32
   DTCINSTALL_E_CLIENT_ALREADY_INSTALLED = 384_i32
   DTCINSTALL_E_SERVER_ALREADY_INSTALLED = 385_i32

--- a/src/win32cr/system/environment.cr
+++ b/src/win32cr/system/environment.cr
@@ -1,11 +1,21 @@
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:userenv.dll")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-core-enclave-l1-1-1.dll")]
+@[Link(ldflags: "/DELAYLOAD:onecore.dll")]
 @[Link(ldflags: "/DELAYLOAD:vertdll.dll")]
+{% else %}
+@[Link("userenv")]
+@[Link("onecore")]
+@[Link("vertdll")]
+{% end %}
 lib LibWin32
   ENCLAVE_RUNTIME_POLICY_ALLOW_FULL_DEBUG = 1_u32
   ENCLAVE_RUNTIME_POLICY_ALLOW_DYNAMIC_DEBUG = 2_u32

--- a/src/win32cr/system/errorreporting.cr
+++ b/src/win32cr/system/errorreporting.cr
@@ -1,11 +1,20 @@
 require "../foundation.cr"
 require "../system/diagnostics/debug.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:wer.dll")]
 @[Link(ldflags: "/DELAYLOAD:faultrep.dll")]
+{% else %}
+@[Link("wer")]
+@[Link("faultrep")]
+{% end %}
 lib LibWin32
   alias HREPORT = LibC::IntPtrT
   alias HREPORTSTORE = LibC::IntPtrT

--- a/src/win32cr/system/eventcollector.cr
+++ b/src/win32cr/system/eventcollector.cr
@@ -1,9 +1,17 @@
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:wecapi.dll")]
+{% else %}
+@[Link("wecapi")]
+{% end %}
 lib LibWin32
   EC_VARIANT_TYPE_MASK = 127_u32
   EC_VARIANT_TYPE_ARRAY = 128_u32

--- a/src/win32cr/system/eventlog.cr
+++ b/src/win32cr/system/eventlog.cr
@@ -1,10 +1,19 @@
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:wevtapi.dll")]
 @[Link(ldflags: "/DELAYLOAD:advapi32.dll")]
+{% else %}
+@[Link("wevtapi")]
+@[Link("advapi32")]
+{% end %}
 lib LibWin32
   alias EventLogHandle = LibC::IntPtrT
   alias EventSourceHandle = LibC::IntPtrT

--- a/src/win32cr/system/eventnotificationservice.cr
+++ b/src/win32cr/system/eventnotificationservice.cr
@@ -1,10 +1,18 @@
 require "../system/com.cr"
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:sensapi.dll")]
+{% else %}
+@[Link("sensapi")]
+{% end %}
 lib LibWin32
   NETWORK_ALIVE_LAN = 1_u32
   NETWORK_ALIVE_WAN = 2_u32

--- a/src/win32cr/system/grouppolicy.cr
+++ b/src/win32cr/system/grouppolicy.cr
@@ -7,12 +7,22 @@ require "../ui/controls.cr"
 require "../security.cr"
 require "../ui/shell.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:userenv.dll")]
 @[Link(ldflags: "/DELAYLOAD:advapi32.dll")]
 @[Link(ldflags: "/DELAYLOAD:gpedit.dll")]
+{% else %}
+@[Link("userenv")]
+@[Link("advapi32")]
+@[Link("gpedit")]
+{% end %}
 lib LibWin32
   alias CriticalPolicySectionHandle = LibC::IntPtrT
 

--- a/src/win32cr/system/hostcompute.cr
+++ b/src/win32cr/system/hostcompute.cr
@@ -1,6 +1,13 @@
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   alias HCS_CALLBACK = LibC::IntPtrT
 

--- a/src/win32cr/system/hostcomputenetwork.cr
+++ b/src/win32cr/system/hostcomputenetwork.cr
@@ -1,9 +1,17 @@
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:computenetwork.dll")]
+{% else %}
+@[Link("computenetwork")]
+{% end %}
 lib LibWin32
   alias HCN_NOTIFICATION_CALLBACK = Proc(UInt32, Void*, HRESULT, LibC::LPWSTR, Void)
 

--- a/src/win32cr/system/hostcomputesystem.cr
+++ b/src/win32cr/system/hostcomputesystem.cr
@@ -1,11 +1,20 @@
 require "../foundation.cr"
 require "../security.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:computecore.dll")]
 @[Link(ldflags: "/DELAYLOAD:computestorage.dll")]
+{% else %}
+@[Link("computecore")]
+@[Link("computestorage")]
+{% end %}
 lib LibWin32
   alias HCS_OPERATION = LibC::IntPtrT
   alias HCS_SYSTEM = LibC::IntPtrT

--- a/src/win32cr/system/hypervisor.cr
+++ b/src/win32cr/system/hypervisor.cr
@@ -2,13 +2,24 @@ require "../foundation.cr"
 require "../system/power.cr"
 require "../system/hostcomputesystem.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:winhvplatform.dll")]
 @[Link(ldflags: "/DELAYLOAD:winhvemulation.dll")]
 @[Link(ldflags: "/DELAYLOAD:vmdevicehost.dll")]
 @[Link(ldflags: "/DELAYLOAD:vmsavedstatedumpprovider.dll")]
+{% else %}
+@[Link("winhvplatform")]
+@[Link("winhvemulation")]
+@[Link("vmdevicehost")]
+@[Link("vmsavedstatedumpprovider")]
+{% end %}
 lib LibWin32
   alias WHV_PARTITION_HANDLE = LibC::IntPtrT
 

--- a/src/win32cr/system/iis.cr
+++ b/src/win32cr/system/iis.cr
@@ -2,10 +2,18 @@ require "../foundation.cr"
 require "../system/com.cr"
 require "../security/cryptography.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:rpcproxy.dll")]
+{% else %}
+@[Link("rpcproxy")]
+{% end %}
 lib LibWin32
   ADMINDATA_MAX_NAME_LEN = 256_u32
   CLSID_MSAdminBase_W = "a9e69610-b80d-11d0-b9b9-00a0c922e750"

--- a/src/win32cr/system/io.cr
+++ b/src/win32cr/system/io.cr
@@ -1,8 +1,15 @@
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   alias LPOVERLAPPED_COMPLETION_ROUTINE = Proc(UInt32, UInt32, OVERLAPPED*, Void)
 

--- a/src/win32cr/system/ioctl.cr
+++ b/src/win32cr/system/ioctl.cr
@@ -3,9 +3,16 @@ require "../storage/filesystem.cr"
 require "../security.cr"
 require "../storage/vhd.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   IOCTL_STORAGE_BASE = 45_u32
   IOCTL_SCMBUS_BASE = 89_u32

--- a/src/win32cr/system/jobobjects.cr
+++ b/src/win32cr/system/jobobjects.cr
@@ -2,10 +2,18 @@ require "../foundation.cr"
 require "../system/threading.cr"
 require "../security.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:user32.dll")]
+{% else %}
+@[Link("user32")]
+{% end %}
 lib LibWin32
 
   enum JOB_OBJECT_LIMIT : UInt32

--- a/src/win32cr/system/js.cr
+++ b/src/win32cr/system/js.cr
@@ -2,10 +2,18 @@ require "../system/diagnostics/debug.cr"
 require "../foundation.cr"
 require "../system/com.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:chakra.dll")]
+{% else %}
+@[Link("chakra")]
+{% end %}
 lib LibWin32
   JS_SOURCE_CONTEXT_NONE = 18446744073709551615_u64
 

--- a/src/win32cr/system/kernel.cr
+++ b/src/win32cr/system/kernel.cr
@@ -1,9 +1,16 @@
 require "../foundation.cr"
 require "../system/diagnostics/debug.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   OBJ_HANDLE_TAGBITS = 3_i32
   RTL_BALANCED_NODE_RESERVED_PARENT_MASK = 3_u32

--- a/src/win32cr/system/libraryloader.cr
+++ b/src/win32cr/system/libraryloader.cr
@@ -1,8 +1,15 @@
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   FIND_RESOURCE_DIRECTORY_TYPES = 256_u32
   FIND_RESOURCE_DIRECTORY_NAMES = 512_u32

--- a/src/win32cr/system/mailslots.cr
+++ b/src/win32cr/system/mailslots.cr
@@ -1,9 +1,16 @@
 require "../foundation.cr"
 require "../security.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
 
   # Params # lpname : PSTR [In],nmaxmessagesize : UInt32 [In],lreadtimeout : UInt32 [In],lpsecurityattributes : SECURITY_ATTRIBUTES* [In]

--- a/src/win32cr/system/mapi.cr
+++ b/src/win32cr/system/mapi.cr
@@ -1,9 +1,17 @@
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:mapi32.dll")]
+{% else %}
+@[Link("mapi32")]
+{% end %}
 lib LibWin32
   MAPI_OLE = 1_u32
   MAPI_OLE_STATIC = 2_u32

--- a/src/win32cr/system/memory.cr
+++ b/src/win32cr/system/memory.cr
@@ -1,15 +1,18 @@
 require "../foundation.cr"
 require "../security.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-core-memory-l1-1-3.dll")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-core-memory-l1-1-7.dll")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-core-memory-l1-1-4.dll")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-core-memory-l1-1-5.dll")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-core-memory-l1-1-6.dll")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-core-memory-l1-1-8.dll")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+@[Link(ldflags: "/DELAYLOAD:onecore.dll")]
+{% else %}
+@[Link("onecore")]
+{% end %}
 lib LibWin32
   alias HeapHandle = LibC::IntPtrT
 

--- a/src/win32cr/system/memory/nonvolatile.cr
+++ b/src/win32cr/system/memory/nonvolatile.cr
@@ -1,7 +1,14 @@
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   struct NV_MEMORY_RANGE
     base_address : Void*

--- a/src/win32cr/system/messagequeuing.cr
+++ b/src/win32cr/system/messagequeuing.cr
@@ -1,9 +1,16 @@
 require "../system/com.cr"
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   PRLT = 0_u32
   PRLE = 1_u32

--- a/src/win32cr/system/mixedreality.cr
+++ b/src/win32cr/system/mixedreality.cr
@@ -1,6 +1,13 @@
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   PERCEPTIONFIELD_StateStream_TimeStamps = "aa886119-f32f-49bf-92ca-f9ddf784d297"
 

--- a/src/win32cr/system/mmc.cr
+++ b/src/win32cr/system/mmc.cr
@@ -4,9 +4,16 @@ require "../ui/controls.cr"
 require "../graphics/gdi.cr"
 require "../ui/windowsandmessaging.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   MMC_VER = 512_u32
   MMC_PROP_CHANGEAFFECTSUI = 1_u32

--- a/src/win32cr/system/ole.cr
+++ b/src/win32cr/system/ole.cr
@@ -7,13 +7,24 @@ require "../media.cr"
 require "../ui/controls/dialogs.cr"
 require "../ui/controls.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:oleaut32.dll")]
 @[Link(ldflags: "/DELAYLOAD:ole32.dll")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-core-marshal-l1-1-0.dll")]
+@[Link(ldflags: "/DELAYLOAD:strmbase.dll")]
 @[Link(ldflags: "/DELAYLOAD:oledlg.dll")]
+{% else %}
+@[Link("oleaut32")]
+@[Link("ole32")]
+@[Link("strmbase")]
+@[Link("oledlg")]
+{% end %}
 lib LibWin32
   CTL_E_ILLEGALFUNCTIONCALL = -2146828283_i32
   CONNECT_E_FIRST = -2147220992_i32

--- a/src/win32cr/system/parentalcontrols.cr
+++ b/src/win32cr/system/parentalcontrols.cr
@@ -1,9 +1,16 @@
 require "../system/com.cr"
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   ARRAY_SEP_CHAR = 9_u32
   WPCCHANNEL = 16_u32

--- a/src/win32cr/system/passwordmanagement.cr
+++ b/src/win32cr/system/passwordmanagement.cr
@@ -1,9 +1,17 @@
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:advapi32.dll")]
+{% else %}
+@[Link("advapi32")]
+{% end %}
 lib LibWin32
   struct CYPHER_BLOCK
     data : CHAR[8]*

--- a/src/win32cr/system/performance.cr
+++ b/src/win32cr/system/performance.cr
@@ -2,12 +2,22 @@ require "../foundation.cr"
 require "../system/com.cr"
 require "../system/ole.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:loadperf.dll")]
 @[Link(ldflags: "/DELAYLOAD:advapi32.dll")]
 @[Link(ldflags: "/DELAYLOAD:pdh.dll")]
+{% else %}
+@[Link("loadperf")]
+@[Link("advapi32")]
+@[Link("pdh")]
+{% end %}
 lib LibWin32
   alias PerfProviderHandle = LibC::IntPtrT
   alias PerfQueryHandle = LibC::IntPtrT

--- a/src/win32cr/system/performance/hardwarecounterprofiling.cr
+++ b/src/win32cr/system/performance/hardwarecounterprofiling.cr
@@ -1,8 +1,15 @@
 require "../../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
 
   enum HARDWARE_COUNTER_TYPE : Int32

--- a/src/win32cr/system/pipes.cr
+++ b/src/win32cr/system/pipes.cr
@@ -3,10 +3,18 @@ require "../security.cr"
 require "../system/io.cr"
 require "../storage/filesystem.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:advapi32.dll")]
+{% else %}
+@[Link("advapi32")]
+{% end %}
 lib LibWin32
   PIPE_UNLIMITED_INSTANCES = 255_u32
   NMPWAIT_WAIT_FOREVER = 4294967295_u32

--- a/src/win32cr/system/power.cr
+++ b/src/win32cr/system/power.cr
@@ -2,11 +2,20 @@ require "../foundation.cr"
 require "../system/registry.cr"
 require "../system/threading.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:powrprof.dll")]
 @[Link(ldflags: "/DELAYLOAD:user32.dll")]
+{% else %}
+@[Link("powrprof")]
+@[Link("user32")]
+{% end %}
 lib LibWin32
   alias HPOWERNOTIFY = LibC::IntPtrT
 

--- a/src/win32cr/system/processstatus.cr
+++ b/src/win32cr/system/processstatus.cr
@@ -1,8 +1,15 @@
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   PSAPI_VERSION = 2_u32
 

--- a/src/win32cr/system/realtimecommunications.cr
+++ b/src/win32cr/system/realtimecommunications.cr
@@ -3,9 +3,16 @@ require "../foundation.cr"
 require "../media/directshow.cr"
 require "../networking/winsock.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   RTCCS_FORCE_PROFILE = 1_u32
   RTCCS_FAIL_ON_REDIRECT = 2_u32

--- a/src/win32cr/system/recovery.cr
+++ b/src/win32cr/system/recovery.cr
@@ -1,9 +1,16 @@
 require "../foundation.cr"
 require "../system/windowsprogramming.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
 
   enum REGISTER_APPLICATION_RESTART_FLAGS : UInt32

--- a/src/win32cr/system/registry.cr
+++ b/src/win32cr/system/registry.cr
@@ -1,11 +1,20 @@
 require "../foundation.cr"
 require "../security.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:advapi32.dll")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-core-state-helpers-l1-1-0.dll")]
+@[Link(ldflags: "/DELAYLOAD:onecore.dll")]
+{% else %}
+@[Link("advapi32")]
+@[Link("onecore")]
+{% end %}
 lib LibWin32
   alias HKEY = LibC::IntPtrT
 

--- a/src/win32cr/system/remoteassistance.cr
+++ b/src/win32cr/system/remoteassistance.cr
@@ -1,9 +1,16 @@
 require "../system/com.cr"
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   DISPID_EVENT_ON_STATE_CHANGED = 5_u32
   DISPID_EVENT_ON_TERMINATION = 6_u32

--- a/src/win32cr/system/remotedesktop.cr
+++ b/src/win32cr/system/remotedesktop.cr
@@ -7,10 +7,18 @@ require "../system/winrt.cr"
 require "../ui/windowsandmessaging.cr"
 require "../security.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:wtsapi32.dll")]
+{% else %}
+@[Link("wtsapi32")]
+{% end %}
 lib LibWin32
   alias HwtsVirtualChannelHandle = LibC::IntPtrT
 

--- a/src/win32cr/system/remotemanagement.cr
+++ b/src/win32cr/system/remotemanagement.cr
@@ -1,10 +1,18 @@
 require "../foundation.cr"
 require "../system/com.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:wsmsvc.dll")]
+{% else %}
+@[Link("wsmsvc")]
+{% end %}
 lib LibWin32
   WSMAN_FLAG_REQUESTED_API_VERSION_1_0 = 0_u32
   WSMAN_FLAG_REQUESTED_API_VERSION_1_1 = 1_u32

--- a/src/win32cr/system/restartmanager.cr
+++ b/src/win32cr/system/restartmanager.cr
@@ -1,9 +1,17 @@
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:rstrtmgr.dll")]
+{% else %}
+@[Link("rstrtmgr")]
+{% end %}
 lib LibWin32
   CCH_RM_SESSION_KEY = 32_u32
   CCH_RM_MAX_APP_NAME = 255_u32

--- a/src/win32cr/system/restore.cr
+++ b/src/win32cr/system/restore.cr
@@ -1,9 +1,17 @@
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:sfc.dll")]
+{% else %}
+@[Link("sfc")]
+{% end %}
 lib LibWin32
   MIN_EVENT = 100_u32
   BEGIN_NESTED_SYSTEM_CHANGE_NORP = 104_u32

--- a/src/win32cr/system/rpc.cr
+++ b/src/win32cr/system/rpc.cr
@@ -3,11 +3,20 @@ require "../foundation.cr"
 require "../system/io.cr"
 require "../security/cryptography.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:rpcrt4.dll")]
 @[Link(ldflags: "/DELAYLOAD:rpcns4.dll")]
+{% else %}
+@[Link("rpcrt4")]
+@[Link("rpcns4")]
+{% end %}
 lib LibWin32
   RPC_C_BINDING_INFINITE_TIMEOUT = 10_u32
   RPC_C_BINDING_MIN_TIMEOUT = 0_u32

--- a/src/win32cr/system/search.cr
+++ b/src/win32cr/system/search.cr
@@ -8,11 +8,20 @@ require "../system/distributedtransactioncoordinator.cr"
 require "../security/authorization.cr"
 require "../ui/shell/common.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:odbc32.dll")]
 @[Link(ldflags: "/DELAYLOAD:odbcbcp.dll")]
+{% else %}
+@[Link("odbc32")]
+@[Link("odbcbcp")]
+{% end %}
 lib LibWin32
   SI_TEMPORARY = 2147483648_u32
   SUBSINFO_ALLFLAGS = 61311_u32

--- a/src/win32cr/system/search/common.cr
+++ b/src/win32cr/system/search/common.cr
@@ -1,6 +1,13 @@
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
 
   enum CONDITION_TYPE : Int32

--- a/src/win32cr/system/securitycenter.cr
+++ b/src/win32cr/system/securitycenter.cr
@@ -2,10 +2,18 @@ require "../system/com.cr"
 require "../foundation.cr"
 require "../system/threading.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:wscapi.dll")]
+{% else %}
+@[Link("wscapi")]
+{% end %}
 lib LibWin32
   WSCProductList = LibC::GUID.new(0x17072f7b_u32, 0x9abe_u16, 0x4a74_u16, StaticArray[0xa2_u8, 0x61_u8, 0x1e_u8, 0xb7_u8, 0x6b_u8, 0x55_u8, 0x10_u8, 0x7a_u8])
   WSCDefaultProduct = LibC::GUID.new(0x2981a36e_u32, 0xf22d_u16, 0x11e5_u16, StaticArray[0x9c_u8, 0xe9_u8, 0x5e_u8, 0x55_u8, 0x17_u8, 0x50_u8, 0x7c_u8, 0x66_u8])

--- a/src/win32cr/system/serverbackup.cr
+++ b/src/win32cr/system/serverbackup.cr
@@ -1,9 +1,16 @@
 require "../system/com.cr"
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   WSB_MAX_OB_STATUS_VALUE_TYPE_PAIR = 5_u32
   WSB_MAX_OB_STATUS_ENTRY = 5_u32

--- a/src/win32cr/system/services.cr
+++ b/src/win32cr/system/services.cr
@@ -2,13 +2,18 @@ require "../foundation.cr"
 require "../security.cr"
 require "../system/registry.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:advapi32.dll")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-service-core-l1-1-3.dll")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-service-core-l1-1-4.dll")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-service-core-l1-1-5.dll")]
+{% else %}
+@[Link("advapi32")]
+{% end %}
 lib LibWin32
   alias SERVICE_STATUS_HANDLE = LibC::IntPtrT
 

--- a/src/win32cr/system/settingsmanagementinfrastructure.cr
+++ b/src/win32cr/system/settingsmanagementinfrastructure.cr
@@ -1,9 +1,16 @@
 require "../system/com.cr"
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   WCM_SETTINGS_ID_FLAG_REFERENCE = 0_u32
   WCM_SETTINGS_ID_FLAG_DEFINITION = 1_u32

--- a/src/win32cr/system/setupandmigration.cr
+++ b/src/win32cr/system/setupandmigration.cr
@@ -1,8 +1,15 @@
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   alias OOBE_COMPLETED_CALLBACK = Proc(Void*, Void)
 

--- a/src/win32cr/system/shutdown.cr
+++ b/src/win32cr/system/shutdown.cr
@@ -1,10 +1,19 @@
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:advapi32.dll")]
 @[Link(ldflags: "/DELAYLOAD:user32.dll")]
+{% else %}
+@[Link("advapi32")]
+@[Link("user32")]
+{% end %}
 lib LibWin32
   MAX_REASON_NAME_LEN = 64_u32
   MAX_REASON_DESC_LEN = 256_u32

--- a/src/win32cr/system/sideshow.cr
+++ b/src/win32cr/system/sideshow.cr
@@ -4,9 +4,16 @@ require "../ui/windowsandmessaging.cr"
 require "../ui/shell/propertiessystem.cr"
 require "../system/com/structuredstorage.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   SIDESHOW_ENDPOINT_SIMPLE_CONTENT_FORMAT = "a9a5353f-2d4b-47ce-93ee-759f3a7dda4f"
   SIDESHOW_ENDPOINT_ICAL = "4dff36b5-9dde-4f76-9a2a-96435047063d"

--- a/src/win32cr/system/sqllite.cr
+++ b/src/win32cr/system/sqllite.cr
@@ -1,9 +1,17 @@
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:winsqlite3.dll")]
+{% else %}
+@[Link("winsqlite3")]
+{% end %}
 lib LibWin32
   SQLITE_VERSION_NUMBER = 3029000_u32
   SQLITE_OK = 0_u32

--- a/src/win32cr/system/stationsanddesktops.cr
+++ b/src/win32cr/system/stationsanddesktops.cr
@@ -3,10 +3,18 @@ require "../graphics/gdi.cr"
 require "../security.cr"
 require "../ui/windowsandmessaging.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:user32.dll")]
+{% else %}
+@[Link("user32")]
+{% end %}
 lib LibWin32
   alias HWINSTA = LibC::IntPtrT
   alias HDESK = LibC::IntPtrT

--- a/src/win32cr/system/subsystemforlinux.cr
+++ b/src/win32cr/system/subsystemforlinux.cr
@@ -1,9 +1,17 @@
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-wsl-api-l1-1-0.dll")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+@[Link(ldflags: "/DELAYLOAD:wslapi.dll")]
+{% else %}
+@[Link("wslapi")]
+{% end %}
 lib LibWin32
 
   enum WSL_DISTRIBUTION_FLAGS : UInt32

--- a/src/win32cr/system/systeminformation.cr
+++ b/src/win32cr/system/systeminformation.cr
@@ -1,14 +1,18 @@
 require "../system/diagnostics/debug.cr"
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-core-sysinfo-l1-2-4.dll")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-core-sysinfo-l1-2-0.dll")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-core-sysinfo-l1-2-3.dll")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-core-wow64-l1-1-1.dll")]
-@[Link(ldflags: "/DELAYLOAD:ntdllk.dll")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+@[Link(ldflags: "/DELAYLOAD:onecore.dll")]
+{% else %}
+@[Link("onecore")]
+{% end %}
 lib LibWin32
   alias FIRMWARE_TABLE_ID = UInt32
 

--- a/src/win32cr/system/systemservices.cr
+++ b/src/win32cr/system/systemservices.cr
@@ -4,10 +4,18 @@ require "../graphics/gdi.cr"
 require "../system/diagnostics/debug.cr"
 require "../security.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:user32.dll")]
+{% else %}
+@[Link("user32")]
+{% end %}
 lib LibWin32
   MM_HINT_T0 = 1_u32
   MM_HINT_T1 = 2_u32

--- a/src/win32cr/system/taskscheduler.cr
+++ b/src/win32cr/system/taskscheduler.cr
@@ -2,9 +2,16 @@ require "../system/com.cr"
 require "../foundation.cr"
 require "../ui/controls.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   TASK_SUNDAY = 1_u32
   TASK_MONDAY = 2_u32

--- a/src/win32cr/system/threading.cr
+++ b/src/win32cr/system/threading.cr
@@ -4,13 +4,24 @@ require "../system/kernel.cr"
 require "../security.cr"
 require "../system/systeminformation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:vertdll.dll")]
 @[Link(ldflags: "/DELAYLOAD:advapi32.dll")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-core-wow64-l1-1-1.dll")]
+@[Link(ldflags: "/DELAYLOAD:onecore.dll")]
 @[Link(ldflags: "/DELAYLOAD:user32.dll")]
+{% else %}
+@[Link("vertdll")]
+@[Link("advapi32")]
+@[Link("onecore")]
+@[Link("user32")]
+{% end %}
 lib LibWin32
   alias TimerQueueHandle = LibC::IntPtrT
   alias PTP_POOL = LibC::IntPtrT

--- a/src/win32cr/system/time.cr
+++ b/src/win32cr/system/time.cr
@@ -1,9 +1,17 @@
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:advapi32.dll")]
+{% else %}
+@[Link("advapi32")]
+{% end %}
 lib LibWin32
   TSF_Hardware = 1_u32
   TSF_Authenticated = 2_u32

--- a/src/win32cr/system/tpmbaseservices.cr
+++ b/src/win32cr/system/tpmbaseservices.cr
@@ -1,9 +1,17 @@
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:tbs.dll")]
+{% else %}
+@[Link("tbs")]
+{% end %}
 lib LibWin32
   TBS_CONTEXT_VERSION_ONE = 1_u32
   TBS_SUCCESS = 0_u32

--- a/src/win32cr/system/transactionserver.cr
+++ b/src/win32cr/system/transactionserver.cr
@@ -1,9 +1,16 @@
 require "../system/com.cr"
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   Catalog = LibC::GUID.new(0x6eb22881_u32, 0x8a19_u16, 0x11d0_u16, StaticArray[0x81_u8, 0xb6_u8, 0x0_u8, 0xa0_u8, 0xc9_u8, 0x23_u8, 0x1c_u8, 0x29_u8])
   CatalogObject = LibC::GUID.new(0x6eb22882_u32, 0x8a19_u16, 0x11d0_u16, StaticArray[0x81_u8, 0xb6_u8, 0x0_u8, 0xa0_u8, 0xc9_u8, 0x23_u8, 0x1c_u8, 0x29_u8])

--- a/src/win32cr/system/updateagent.cr
+++ b/src/win32cr/system/updateagent.cr
@@ -1,9 +1,16 @@
 require "../system/com.cr"
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   LIBID_WUApiLib = "b596cc9f-56e5-419e-a622-e01bb457431e"
   UPDATE_LOCKDOWN_WEBSITE_ACCESS = 1_u32

--- a/src/win32cr/system/updateassessment.cr
+++ b/src/win32cr/system/updateassessment.cr
@@ -1,9 +1,16 @@
 require "../foundation.cr"
 require "../system/com.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   WaaSAssessor = LibC::GUID.new(0x98ef871_u32, 0xfa9f_u16, 0x46af_u16, StaticArray[0x89_u8, 0x58_u8, 0xc0_u8, 0x83_u8, 0x51_u8, 0x5d_u8, 0x7c_u8, 0x9c_u8])
 

--- a/src/win32cr/system/useraccesslogging.cr
+++ b/src/win32cr/system/useraccesslogging.cr
@@ -1,10 +1,18 @@
 require "../networking/winsock.cr"
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:ualapi.dll")]
+{% else %}
+@[Link("ualapi")]
+{% end %}
 lib LibWin32
   struct UAL_DATA_BLOB
     size : UInt32

--- a/src/win32cr/system/virtualdosmachines.cr
+++ b/src/win32cr/system/virtualdosmachines.cr
@@ -2,9 +2,16 @@ require "../system/kernel.cr"
 require "../foundation.cr"
 require "../system/diagnostics/debug.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   VDMCONTEXT_i386 = 65536_u32
   VDMCONTEXT_i486 = 65536_u32

--- a/src/win32cr/system/windowsprogramming.cr
+++ b/src/win32cr/system/windowsprogramming.cr
@@ -5,22 +5,32 @@ require "../security.cr"
 require "../graphics/gdi.cr"
 require "../system/registry.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-core-apiquery-l2-1-0.dll")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-core-realtime-l1-1-1.dll")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-core-realtime-l1-1-2.dll")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+@[Link(ldflags: "/DELAYLOAD:onecore.dll")]
 @[Link(ldflags: "/DELAYLOAD:advapi32.dll")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-core-backgroundtask-l1-1-0.dll")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-core-featurestaging-l1-1-0.dll")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-core-featurestaging-l1-1-1.dll")]
+@[Link(ldflags: "/DELAYLOAD:shcore.dll")]
 @[Link(ldflags: "/DELAYLOAD:dciman32.dll")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-dx-d3dkmt-l1-1-0.dll")]
+@[Link(ldflags: "/DELAYLOAD:gdi32.dll")]
 @[Link(ldflags: "/DELAYLOAD:advpack.dll")]
 @[Link(ldflags: "/DELAYLOAD:user32.dll")]
-@[Link(ldflags: "/DELAYLOAD:apphelp.dll")]
 @[Link(ldflags: "/DELAYLOAD:wldp.dll")]
+{% else %}
+@[Link("onecore")]
+@[Link("advapi32")]
+@[Link("shcore")]
+@[Link("dciman32")]
+@[Link("gdi32")]
+@[Link("advpack")]
+@[Link("user32")]
+@[Link("wldp")]
+{% end %}
 lib LibWin32
   alias HWINWATCH = LibC::IntPtrT
   alias FEATURE_STATE_CHANGE_SUBSCRIPTION = LibC::IntPtrT

--- a/src/win32cr/system/windowssync.cr
+++ b/src/win32cr/system/windowssync.cr
@@ -2,9 +2,16 @@ require "../foundation.cr"
 require "../system/com.cr"
 require "../ui/shell/propertiessystem.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   SYNC_VERSION_FLAG_FROM_FEED = 1_u32
   SYNC_VERSION_FLAG_HAS_BY = 2_u32

--- a/src/win32cr/system/winrt.cr
+++ b/src/win32cr/system/winrt.cr
@@ -3,21 +3,26 @@ require "../foundation.cr"
 require "../ui/shell/propertiessystem.cr"
 require "../system/com/marshal.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:ole32.dll")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-core-winrt-string-l1-1-0.dll")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-core-winrt-string-l1-1-1.dll")]
+@[Link(ldflags: "/DELAYLOAD:strmbase.dll")]
 @[Link(ldflags: "/DELAYLOAD:coremessaging.dll")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-core-winrt-l1-1-0.dll")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-core-winrt-robuffer-l1-1-0.dll")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-core-winrt-error-l1-1-0.dll")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-core-winrt-error-l1-1-1.dll")]
 @[Link(ldflags: "/DELAYLOAD:rometadata.dll")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-core-winrt-roparameterizediid-l1-1-0.dll")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-core-winrt-registration-l1-1-0.dll")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-shcore-stream-winrt-l1-1-0.dll")]
+@[Link(ldflags: "/DELAYLOAD:shcore.dll")]
+{% else %}
+@[Link("ole32")]
+@[Link("strmbase")]
+@[Link("coremessaging")]
+@[Link("rometadata")]
+@[Link("shcore")]
+{% end %}
 lib LibWin32
   alias HSTRING = LibC::IntPtrT
   alias HSTRING_BUFFER = LibC::IntPtrT

--- a/src/win32cr/system/winrt/alljoyn.cr
+++ b/src/win32cr/system/winrt/alljoyn.cr
@@ -1,9 +1,16 @@
 require "../../system/winrt.cr"
 require "../../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
 
   struct IWindowsDevicesAllJoynBusAttachmentInteropVTbl

--- a/src/win32cr/system/winrt/composition.cr
+++ b/src/win32cr/system/winrt/composition.cr
@@ -3,9 +3,16 @@ require "../../foundation.cr"
 require "../../ui/input/pointer.cr"
 require "../../system/winrt.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
 
   struct ICompositionDrawingSurfaceInteropVTbl

--- a/src/win32cr/system/winrt/coreinputview.cr
+++ b/src/win32cr/system/winrt/coreinputview.cr
@@ -1,9 +1,16 @@
 require "../../system/winrt.cr"
 require "../../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
 
   struct ICoreFrameworkInputViewInteropVTbl

--- a/src/win32cr/system/winrt/direct3d11.cr
+++ b/src/win32cr/system/winrt/direct3d11.cr
@@ -3,10 +3,18 @@ require "../../foundation.cr"
 require "../../graphics/dxgi.cr"
 require "../../system/winrt.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:d3d11.dll")]
+{% else %}
+@[Link("d3d11")]
+{% end %}
 lib LibWin32
 
   struct IDirect3DDxgiInterfaceAccessVTbl

--- a/src/win32cr/system/winrt/display.cr
+++ b/src/win32cr/system/winrt/display.cr
@@ -3,9 +3,16 @@ require "../../foundation.cr"
 require "../../system/winrt.cr"
 require "../../security.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
 
   struct IDisplayDeviceInteropVTbl

--- a/src/win32cr/system/winrt/graphics/capture.cr
+++ b/src/win32cr/system/winrt/graphics/capture.cr
@@ -2,9 +2,16 @@ require "../../../system/com.cr"
 require "../../../foundation.cr"
 require "../../../graphics/gdi.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
 
   struct IGraphicsCaptureItemInteropVTbl

--- a/src/win32cr/system/winrt/graphics/direct2d.cr
+++ b/src/win32cr/system/winrt/graphics/direct2d.cr
@@ -2,9 +2,16 @@ require "../../../system/com.cr"
 require "../../../foundation.cr"
 require "../../../graphics/direct2d.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
 
   enum GRAPHICS_EFFECT_PROPERTY_MAPPING : Int32

--- a/src/win32cr/system/winrt/graphics/imaging.cr
+++ b/src/win32cr/system/winrt/graphics/imaging.cr
@@ -3,9 +3,16 @@ require "../../../foundation.cr"
 require "../../../graphics/imaging.cr"
 require "../../../media/mediafoundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   CLSID_SoftwareBitmapNativeFactory = "84e65691-8602-4a84-be46-708be9cd4b74"
 

--- a/src/win32cr/system/winrt/holographic.cr
+++ b/src/win32cr/system/winrt/holographic.cr
@@ -2,9 +2,16 @@ require "../../system/winrt.cr"
 require "../../foundation.cr"
 require "../../graphics/direct3d12.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
 
   struct IHolographicCameraInteropVTbl

--- a/src/win32cr/system/winrt/isolation.cr
+++ b/src/win32cr/system/winrt/isolation.cr
@@ -1,9 +1,16 @@
 require "../../system/com.cr"
 require "../../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
 
   struct IIsolatedEnvironmentInteropVTbl

--- a/src/win32cr/system/winrt/media.cr
+++ b/src/win32cr/system/winrt/media.cr
@@ -2,9 +2,16 @@ require "../../system/winrt.cr"
 require "../../foundation.cr"
 require "../../media/mediafoundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   CLSID_AudioFrameNativeFactory = "16a0a3b9-9f65-4102-9367-2cda3a4f372a"
   CLSID_VideoFrameNativeFactory = "d194386a-04e3-4814-8100-b2b0ae6d78c7"

--- a/src/win32cr/system/winrt/ml.cr
+++ b/src/win32cr/system/winrt/ml.cr
@@ -3,9 +3,16 @@ require "../../foundation.cr"
 require "../../ai/machinelearning/winml.cr"
 require "../../graphics/direct3d12.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
 
   struct ILearningModelOperatorProviderNativeVTbl

--- a/src/win32cr/system/winrt/pdf.cr
+++ b/src/win32cr/system/winrt/pdf.cr
@@ -4,10 +4,18 @@ require "../../graphics/direct2d/common.cr"
 require "../../system/com.cr"
 require "../../graphics/direct2d.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:windows.data.pdf.dll")]
+{% else %}
+@[Link("windows.data.pdf")]
+{% end %}
 lib LibWin32
   alias PFN_PDF_CREATE_RENDERER = Proc(IDXGIDevice, IPdfRendererNative*, HRESULT)
 

--- a/src/win32cr/system/winrt/printing.cr
+++ b/src/win32cr/system/winrt/printing.cr
@@ -4,9 +4,16 @@ require "../../system/com.cr"
 require "../../storage/xps.cr"
 require "../../graphics/printing.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
 
   struct IPrinting3DManagerInteropVTbl

--- a/src/win32cr/system/winrt/shell.cr
+++ b/src/win32cr/system/winrt/shell.cr
@@ -2,9 +2,16 @@ require "../../system/com.cr"
 require "../../foundation.cr"
 require "../../ui/shell.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
 
   enum CreateProcessMethod : Int32

--- a/src/win32cr/system/winrt/storage.cr
+++ b/src/win32cr/system/winrt/storage.cr
@@ -1,9 +1,16 @@
 require "../../system/com.cr"
 require "../../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
 
   enum HANDLE_OPTIONS : UInt32

--- a/src/win32cr/system/winrt/xaml.cr
+++ b/src/win32cr/system/winrt/xaml.cr
@@ -3,9 +3,16 @@ require "../../foundation.cr"
 require "../../graphics/dxgi.cr"
 require "../../ui/windowsandmessaging.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   E_SURFACE_CONTENTS_LOST = 2150301728_u32
 

--- a/src/win32cr/system/wmi.cr
+++ b/src/win32cr/system/wmi.cr
@@ -1,10 +1,18 @@
 require "../system/com.cr"
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:mi.dll")]
+{% else %}
+@[Link("mi")]
+{% end %}
 lib LibWin32
   MI_FLAG_ANY = 127_u32
   MI_FLAG_VERSION = 469762048_u32

--- a/src/win32cr/ui/accessibility.cr
+++ b/src/win32cr/ui/accessibility.cr
@@ -2,12 +2,22 @@ require "../system/com.cr"
 require "../foundation.cr"
 require "../ui/windowsandmessaging.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:oleacc.dll")]
 @[Link(ldflags: "/DELAYLOAD:uiautomationcore.dll")]
 @[Link(ldflags: "/DELAYLOAD:user32.dll")]
+{% else %}
+@[Link("oleacc")]
+@[Link("uiautomationcore")]
+@[Link("user32")]
+{% end %}
 lib LibWin32
   alias HWINEVENTHOOK = LibC::IntPtrT
   alias HUIANODE = LibC::IntPtrT

--- a/src/win32cr/ui/animation.cr
+++ b/src/win32cr/ui/animation.cr
@@ -2,9 +2,16 @@ require "../system/com.cr"
 require "../foundation.cr"
 require "../graphics/directcomposition.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   alias UI_ANIMATION_KEYFRAME = LibC::IntPtrT
 

--- a/src/win32cr/ui/colorsystem.cr
+++ b/src/win32cr/ui/colorsystem.cr
@@ -3,13 +3,24 @@ require "../foundation.cr"
 require "../system/com.cr"
 require "../ui/windowsandmessaging.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:gdi32.dll")]
 @[Link(ldflags: "/DELAYLOAD:mscms.dll")]
 @[Link(ldflags: "/DELAYLOAD:icmui.dll")]
 @[Link(ldflags: "/DELAYLOAD:icm32.dll")]
+{% else %}
+@[Link("gdi32")]
+@[Link("mscms")]
+@[Link("icmui")]
+@[Link("icm32")]
+{% end %}
 lib LibWin32
   alias HCOLORSPACE = LibC::IntPtrT
 

--- a/src/win32cr/ui/controls.cr
+++ b/src/win32cr/ui/controls.cr
@@ -5,12 +5,22 @@ require "../system/registry.cr"
 require "../system/com.cr"
 require "../ui/input/pointer.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:comctl32.dll")]
 @[Link(ldflags: "/DELAYLOAD:uxtheme.dll")]
 @[Link(ldflags: "/DELAYLOAD:user32.dll")]
+{% else %}
+@[Link("comctl32")]
+@[Link("uxtheme")]
+@[Link("user32")]
+{% end %}
 lib LibWin32
   alias HPROPSHEETPAGE = LibC::IntPtrT
   alias HIMAGELIST = LibC::IntPtrT

--- a/src/win32cr/ui/controls/dialogs.cr
+++ b/src/win32cr/ui/controls/dialogs.cr
@@ -3,10 +3,18 @@ require "../../ui/controls.cr"
 require "../../graphics/gdi.cr"
 require "../../system/com.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:comdlg32.dll")]
+{% else %}
+@[Link("comdlg32")]
+{% end %}
 lib LibWin32
   OFN_SHAREFALLTHROUGH = 2_u32
   OFN_SHARENOWARN = 1_u32

--- a/src/win32cr/ui/controls/richedit.cr
+++ b/src/win32cr/ui/controls/richedit.cr
@@ -8,9 +8,16 @@ require "../../globalization.cr"
 require "../../graphics/direct2d.cr"
 require "../../system/com/structuredstorage.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   WM_CONTEXTMENU = 123_u32
   WM_UNICHAR = 265_u32

--- a/src/win32cr/ui/hidpi.cr
+++ b/src/win32cr/ui/hidpi.cr
@@ -1,12 +1,22 @@
 require "../foundation.cr"
 require "../graphics/gdi.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:uxtheme.dll")]
 @[Link(ldflags: "/DELAYLOAD:user32.dll")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-shcore-scaling-l1-1-1.dll")]
+@[Link(ldflags: "/DELAYLOAD:shcore.dll")]
+{% else %}
+@[Link("uxtheme")]
+@[Link("user32")]
+@[Link("shcore")]
+{% end %}
 lib LibWin32
   alias DPI_AWARENESS_CONTEXT = LibC::IntPtrT
 

--- a/src/win32cr/ui/input.cr
+++ b/src/win32cr/ui/input.cr
@@ -1,9 +1,17 @@
 require "../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:user32.dll")]
+{% else %}
+@[Link("user32")]
+{% end %}
 lib LibWin32
   alias HRAWINPUT = LibC::IntPtrT
 

--- a/src/win32cr/ui/input/ime.cr
+++ b/src/win32cr/ui/input/ime.cr
@@ -5,10 +5,18 @@ require "../../system/com.cr"
 require "../../ui/windowsandmessaging.cr"
 require "../../ui/textservices.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:imm32.dll")]
+{% else %}
+@[Link("imm32")]
+{% end %}
 lib LibWin32
   CLSID_VERSION_DEPENDENT_MSIME_JAPANESE = "6a91029e-aa49-471b-aee7-7d332785660d"
   IFEC_S_ALREADY_DEFAULT = 291840_i32

--- a/src/win32cr/ui/input/ink.cr
+++ b/src/win32cr/ui/input/ink.cr
@@ -1,9 +1,16 @@
 require "../../system/com.cr"
 require "../../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   InkDesktopHost = LibC::GUID.new(0x62584a6_u32, 0xf830_u16, 0x4bdc_u16, StaticArray[0xa4_u8, 0xd2_u8, 0xa_u8, 0x10_u8, 0xab_u8, 0x6_u8, 0x2b_u8, 0x1d_u8])
   InkD2DRenderer = LibC::GUID.new(0x4044e60c_u32, 0x7b01_u16, 0x4671_u16, StaticArray[0xa9_u8, 0x7c_u8, 0x4_u8, 0xe0_u8, 0x21_u8, 0xa_u8, 0x7_u8, 0xa5_u8])

--- a/src/win32cr/ui/input/keyboardandmouse.cr
+++ b/src/win32cr/ui/input/keyboardandmouse.cr
@@ -1,11 +1,20 @@
 require "../../foundation.cr"
 require "../../ui/textservices.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:comctl32.dll")]
 @[Link(ldflags: "/DELAYLOAD:user32.dll")]
+{% else %}
+@[Link("comctl32")]
+@[Link("user32")]
+{% end %}
 lib LibWin32
   EXTENDED_BIT = 16777216_u32
   DONTCARE_BIT = 33554432_u32

--- a/src/win32cr/ui/input/pointer.cr
+++ b/src/win32cr/ui/input/pointer.cr
@@ -2,10 +2,18 @@ require "../../ui/windowsandmessaging.cr"
 require "../../foundation.cr"
 require "../../ui/controls.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:user32.dll")]
+{% else %}
+@[Link("user32")]
+{% end %}
 lib LibWin32
 
   enum POINTER_FLAGS : UInt32

--- a/src/win32cr/ui/input/radial.cr
+++ b/src/win32cr/ui/input/radial.cr
@@ -1,9 +1,16 @@
 require "../../system/winrt.cr"
 require "../../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
 
   struct IRadialControllerInteropVTbl

--- a/src/win32cr/ui/input/touch.cr
+++ b/src/win32cr/ui/input/touch.cr
@@ -1,10 +1,18 @@
 require "../../system/com.cr"
 require "../../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:user32.dll")]
+{% else %}
+@[Link("user32")]
+{% end %}
 lib LibWin32
   alias HGESTUREINFO = LibC::IntPtrT
   alias HTOUCHINPUT = LibC::IntPtrT

--- a/src/win32cr/ui/input/xboxcontroller.cr
+++ b/src/win32cr/ui/input/xboxcontroller.cr
@@ -1,9 +1,17 @@
 require "../../foundation.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:xinputuap.dll")]
+{% else %}
+@[Link("xinputuap")]
+{% end %}
 lib LibWin32
   XINPUT_DEVTYPE_GAMEPAD = 1_u32
   XINPUT_DEVSUBTYPE_GAMEPAD = 1_u32

--- a/src/win32cr/ui/interactioncontext.cr
+++ b/src/win32cr/ui/interactioncontext.cr
@@ -2,10 +2,18 @@ require "../ui/windowsandmessaging.cr"
 require "../foundation.cr"
 require "../ui/input/pointer.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:ninput.dll")]
+{% else %}
+@[Link("ninput")]
+{% end %}
 lib LibWin32
   alias HINTERACTIONCONTEXT = LibC::IntPtrT
 

--- a/src/win32cr/ui/legacywindowsenvironmentfeatures.cr
+++ b/src/win32cr/ui/legacywindowsenvironmentfeatures.cr
@@ -4,9 +4,16 @@ require "../system/registry.cr"
 require "../system/com/structuredstorage.cr"
 require "../system/ole.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   EVCF_HASSETTINGS = 1_u32
   EVCF_ENABLEBYDEFAULT = 2_u32

--- a/src/win32cr/ui/magnification.cr
+++ b/src/win32cr/ui/magnification.cr
@@ -1,10 +1,18 @@
 require "../foundation.cr"
 require "../graphics/gdi.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:magnification.dll")]
+{% else %}
+@[Link("magnification")]
+{% end %}
 lib LibWin32
   MS_SHOWMAGNIFIEDCURSOR = 1_i32
   MS_CLIPAROUNDCURSOR = 2_i32

--- a/src/win32cr/ui/notifications.cr
+++ b/src/win32cr/ui/notifications.cr
@@ -1,9 +1,16 @@
 require "../foundation.cr"
 require "../system/com.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   struct NOTIFICATION_USER_INPUT_DATA
     key : LibC::LPWSTR

--- a/src/win32cr/ui/ribbon.cr
+++ b/src/win32cr/ui/ribbon.cr
@@ -4,9 +4,16 @@ require "../ui/shell/propertiessystem.cr"
 require "../system/com/structuredstorage.cr"
 require "../graphics/gdi.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   UI_ALL_COMMANDS = 0_u32
   UI_COLLECTION_INVALIDINDEX = 4294967295_u32

--- a/src/win32cr/ui/shell.cr
+++ b/src/win32cr/ui/shell.cr
@@ -19,23 +19,38 @@ require "../system/threading.cr"
 require "../graphics/directcomposition.cr"
 require "../system/com/urlmon.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:userenv.dll")]
 @[Link(ldflags: "/DELAYLOAD:comctl32.dll")]
 @[Link(ldflags: "/DELAYLOAD:user32.dll")]
 @[Link(ldflags: "/DELAYLOAD:shell32.dll")]
 @[Link(ldflags: "/DELAYLOAD:ole32.dll")]
 @[Link(ldflags: "/DELAYLOAD:shdocvw.dll")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-shcore-scaling-l1-1-0.dll")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-shcore-scaling-l1-1-1.dll")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-shcore-scaling-l1-1-2.dll")]
+@[Link(ldflags: "/DELAYLOAD:shcore.dll")]
 @[Link(ldflags: "/DELAYLOAD:shlwapi.dll")]
 @[Link(ldflags: "/DELAYLOAD:hlink.dll")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-core-path-l1-1-0.dll")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-core-psm-appnotify-l1-1-0.dll")]
-@[Link(ldflags: "/DELAYLOAD:api-ms-win-core-psm-appnotify-l1-1-1.dll")]
+@[Link(ldflags: "/DELAYLOAD:onecore.dll")]
+@[Link(ldflags: "/DELAYLOAD:twinapi.dll")]
+{% else %}
+@[Link("userenv")]
+@[Link("comctl32")]
+@[Link("user32")]
+@[Link("shell32")]
+@[Link("ole32")]
+@[Link("shdocvw")]
+@[Link("shcore")]
+@[Link("shlwapi")]
+@[Link("hlink")]
+@[Link("onecore")]
+@[Link("twinapi")]
+{% end %}
 lib LibWin32
   alias ShFindChangeNotificationHandle = LibC::IntPtrT
   alias HDROP = LibC::IntPtrT

--- a/src/win32cr/ui/shell/common.cr
+++ b/src/win32cr/ui/shell/common.cr
@@ -1,9 +1,16 @@
 require "../../foundation.cr"
 require "../../system/com.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   PERCEIVEDFLAG_UNDEFINED = 0_u32
   PERCEIVEDFLAG_SOFTCODED = 1_u32

--- a/src/win32cr/ui/shell/propertiessystem.cr
+++ b/src/win32cr/ui/shell/propertiessystem.cr
@@ -4,11 +4,20 @@ require "../../system/com/structuredstorage.cr"
 require "../../system/search/common.cr"
 require "../../ui/shell/common.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:propsys.dll")]
 @[Link(ldflags: "/DELAYLOAD:shell32.dll")]
+{% else %}
+@[Link("propsys")]
+@[Link("shell32")]
+{% end %}
 lib LibWin32
   PKEY_PIDSTR_MAX = 10_u32
   InMemoryPropertyStore = LibC::GUID.new(0x9a02e012_u32, 0x6303_u16, 0x4e1e_u16, StaticArray[0xb9_u8, 0xa1_u8, 0x63_u8, 0xf_u8, 0x80_u8, 0x25_u8, 0x92_u8, 0xc5_u8])

--- a/src/win32cr/ui/tabletpc.cr
+++ b/src/win32cr/ui/tabletpc.cr
@@ -4,10 +4,18 @@ require "../graphics/gdi.cr"
 require "../system/ole.cr"
 require "../ui/controls.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:inkobjcore.dll")]
+{% else %}
+@[Link("inkobjcore")]
+{% end %}
 lib LibWin32
   alias HRECOALT = LibC::IntPtrT
   alias HRECOCONTEXT = LibC::IntPtrT

--- a/src/win32cr/ui/textservices.cr
+++ b/src/win32cr/ui/textservices.cr
@@ -3,10 +3,18 @@ require "../system/com.cr"
 require "../ui/windowsandmessaging.cr"
 require "../graphics/gdi.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:msctfmonitor.dll")]
+{% else %}
+@[Link("msctfmonitor")]
+{% end %}
 lib LibWin32
   alias HKL = LibC::IntPtrT
 

--- a/src/win32cr/ui/windowsandmessaging.cr
+++ b/src/win32cr/ui/windowsandmessaging.cr
@@ -3,11 +3,20 @@ require "../graphics/gdi.cr"
 require "../ui/shell.cr"
 require "../system/power.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:user32.dll")]
 @[Link(ldflags: "/DELAYLOAD:mrmsupport.dll")]
+{% else %}
+@[Link("user32")]
+@[Link("mrmsupport")]
+{% end %}
 lib LibWin32
   alias HHOOK = HANDLE
   alias HICON = HANDLE

--- a/src/win32cr/ui/wpf.cr
+++ b/src/win32cr/ui/wpf.cr
@@ -3,9 +3,16 @@ require "../foundation.cr"
 require "../graphics/imaging.cr"
 require "../graphics/dwm.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
+{% else %}
+{% end %}
 lib LibWin32
   MILBITMAPEFFECT_SDK_VERSION = 16777216_u32
   CLSID_MILBitmapEffectGroup = "ac9c1a9a-7e18-4f64-ac7e-47cf7f051e95"

--- a/src/win32cr/ui/xaml/diagnostics.cr
+++ b/src/win32cr/ui/xaml/diagnostics.cr
@@ -3,10 +3,18 @@ require "../../system/com.cr"
 require "../../graphics/dxgi/common.cr"
 require "../../system/winrt.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:windows.ui.xaml.dll")]
+{% else %}
+@[Link("windows.ui.xaml")]
+{% end %}
 lib LibWin32
   E_UNKNOWNTYPE = -2144665560_i32
 

--- a/src/win32cr/web/mshtml.cr
+++ b/src/win32cr/web/mshtml.cr
@@ -9,12 +9,22 @@ require "../ui/windowsandmessaging.cr"
 require "../system/diagnostics/debug.cr"
 require "../graphics/directdraw.cr"
 
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link("delayimp")]
+{% end %}
 @[Link("user32")]
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
+{% end %}
+{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/DELAYLOAD:msrating.dll")]
 @[Link(ldflags: "/DELAYLOAD:imgutil.dll")]
 @[Link(ldflags: "/DELAYLOAD:shdocvw.dll")]
+{% else %}
+@[Link("msrating")]
+@[Link("imgutil")]
+@[Link("shdocvw")]
+{% end %}
 lib LibWin32
   DISPID_STYLESHEETSCOLLECTION_NAMED_MAX = 1999999_u32
   DISPID_AMBIENT_OFFLINEIFNOTCONNECTED = -5501_i32


### PR DESCRIPTION
Previously we were linking to libraries that dont exist (api-ms-*.dll) in retail windows, they're statically linked in other libraries.