### PR TITLE
Removed empty macro conditionals

### DIFF
--- a/src/win32cr/data/htmlhelp.cr
+++ b/src/win32cr/data/htmlhelp.cr
@@ -10,9 +10,6 @@ require "../system/search.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   HH_DISPLAY_TOPIC = 0_u32
   HH_HELP_FINDER = 0_u32

--- a/src/win32cr/data/xml/msxml.cr
+++ b/src/win32cr/data/xml/msxml.cr
@@ -8,9 +8,6 @@ require "../../system/com.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   E_XML_NOTWF = -1072897501_i32
   E_XML_NODTD = -1072897500_i32

--- a/src/win32cr/devices/functiondiscovery.cr
+++ b/src/win32cr/devices/functiondiscovery.cr
@@ -10,9 +10,6 @@ require "../system/com/structuredstorage.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   FD_EVENTID_PRIVATE = 100_u32
   FD_EVENTID = 1000_u32

--- a/src/win32cr/devices/geolocation.cr
+++ b/src/win32cr/devices/geolocation.cr
@@ -11,9 +11,6 @@ require "../devices/sensors.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   GNSS_DRIVER_VERSION_1 = 1_u32
   GNSS_DRIVER_VERSION_2 = 2_u32

--- a/src/win32cr/devices/imageacquisition.cr
+++ b/src/win32cr/devices/imageacquisition.cr
@@ -11,9 +11,6 @@ require "../graphics/gdi.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   WIA_DIP_DEV_ID = 2_u32
   WIA_DIP_VEND_DESC = 3_u32

--- a/src/win32cr/devices/properties.cr
+++ b/src/win32cr/devices/properties.cr
@@ -7,9 +7,6 @@ require "../foundation.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   DEVPKEY_DeviceInterface_Autoplay_Silent = PROPERTYKEY.new(LibC::GUID.new(0x434dd28f_u32, 0x9e75_u16, 0x450a_u16, StaticArray[0x9a_u8, 0xb9_u8, 0xff_u8, 0x61_u8, 0xe6_u8, 0x18_u8, 0xba_u8, 0xd0_u8]), 2_u32)
   DEVPKEY_NAME = PROPERTYKEY.new(LibC::GUID.new(0xb725f130_u32, 0x47ef_u16, 0x101a_u16, StaticArray[0xa5_u8, 0xf1_u8, 0x2_u8, 0x60_u8, 0x8c_u8, 0x9e_u8, 0xeb_u8, 0xac_u8]), 10_u32)

--- a/src/win32cr/devices/pwm.cr
+++ b/src/win32cr/devices/pwm.cr
@@ -7,9 +7,6 @@ require "../foundation.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   GUID_DEVINTERFACE_PWM_CONTROLLER = "60824b4c-eed1-4c9c-b49c-1b961461a819"
   IOCTL_PWM_CONTROLLER_GET_INFO = 262144_u32

--- a/src/win32cr/graphics.cr
+++ b/src/win32cr/graphics.cr
@@ -5,9 +5,6 @@
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
 
   enum D2D1_2DAFFINETRANSFORM_INTERPOLATION_MODE : UInt32

--- a/src/win32cr/graphics/direct2d/common.cr
+++ b/src/win32cr/graphics/direct2d/common.cr
@@ -9,9 +9,6 @@ require "../../foundation.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
 
   enum D2D1_ALPHA_MODE : UInt32

--- a/src/win32cr/graphics/direct3d.cr
+++ b/src/win32cr/graphics/direct3d.cr
@@ -8,9 +8,6 @@ require "../system/com.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   D3D_FL9_1_REQ_TEXTURE1D_U_DIMENSION = 2048_u32
   D3D_FL9_3_REQ_TEXTURE1D_U_DIMENSION = 4096_u32

--- a/src/win32cr/graphics/directmanipulation.cr
+++ b/src/win32cr/graphics/directmanipulation.cr
@@ -9,9 +9,6 @@ require "../ui/windowsandmessaging.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   DIRECTMANIPULATION_KEYBOARDFOCUS = 4294967294_u32
   DIRECTMANIPULATION_MOUSEFOCUS = 4294967293_u32

--- a/src/win32cr/graphics/dxgi/common.cr
+++ b/src/win32cr/graphics/dxgi/common.cr
@@ -7,9 +7,6 @@ require "../../foundation.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   FACDXGI = 2170_u32
   DXGI_CPU_ACCESS_NONE = 0_u32

--- a/src/win32cr/graphics/hlsl.cr
+++ b/src/win32cr/graphics/hlsl.cr
@@ -5,9 +5,6 @@
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   D3DCOMPILER_DLL = "d3dcompiler_47.dll"
   D3DCOMPILE_OPTIMIZATION_LEVEL2 = 49152_u32

--- a/src/win32cr/graphics/imaging/d2d.cr
+++ b/src/win32cr/graphics/imaging/d2d.cr
@@ -10,9 +10,6 @@ require "../../graphics/imaging.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
 
   struct IWICImageEncoderVTbl

--- a/src/win32cr/media/audio/apo.cr
+++ b/src/win32cr/media/audio/apo.cr
@@ -10,9 +10,6 @@ require "../../ui/shell/propertiessystem.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   APOERR_ALREADY_INITIALIZED = -2005073919_i32
   APOERR_NOT_INITIALIZED = -2005073918_i32

--- a/src/win32cr/media/audio/directmusic.cr
+++ b/src/win32cr/media/audio/directmusic.cr
@@ -13,9 +13,6 @@ require "../../media/multimedia.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   DMUS_MAX_DESCRIPTION = 128_u32
   DMUS_MAX_DRIVER = 128_u32

--- a/src/win32cr/media/audio/endpoints.cr
+++ b/src/win32cr/media/audio/endpoints.cr
@@ -11,9 +11,6 @@ require "../../media/audio/apo.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   DEVPKEY_AudioEndpointPlugin_FactoryCLSID = PROPERTYKEY.new(LibC::GUID.new(0x12d83bd7_u32, 0xcf12_u16, 0x46be_u16, StaticArray[0x85_u8, 0x40_u8, 0x81_u8, 0x27_u8, 0x10_u8, 0xd3_u8, 0x2_u8, 0x1c_u8]), 1_u32)
   DEVPKEY_AudioEndpointPlugin_DataFlow = PROPERTYKEY.new(LibC::GUID.new(0x12d83bd7_u32, 0xcf12_u16, 0x46be_u16, StaticArray[0x85_u8, 0x40_u8, 0x81_u8, 0x27_u8, 0x10_u8, 0xd3_u8, 0x2_u8, 0x1c_u8]), 2_u32)

--- a/src/win32cr/media/devicemanager.cr
+++ b/src/win32cr/media/devicemanager.cr
@@ -10,9 +10,6 @@ require "../system/ole.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   IOCTL_MTP_CUSTOM_COMMAND = 827348045_u32
   MTP_NEXTPHASE_READ_DATA = 1_u32

--- a/src/win32cr/media/directshow/xml.cr
+++ b/src/win32cr/media/directshow/xml.cr
@@ -10,9 +10,6 @@ require "../../data/xml/msxml.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   CLSID_XMLGraphBuilder = "1bb05961-5fbf-11d2-a521-44df07c10000"
 

--- a/src/win32cr/media/librarysharingservices.cr
+++ b/src/win32cr/media/librarysharingservices.cr
@@ -8,9 +8,6 @@ require "../foundation.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   CLSID_WindowsMediaLibrarySharingServices = LibC::GUID.new(0xad581b00_u32, 0x7b64_u16, 0x4e59_u16, StaticArray[0xa3_u8, 0x8d_u8, 0xd2_u8, 0xc5_u8, 0xbf_u8, 0x51_u8, 0xdd_u8, 0xb3_u8])
 

--- a/src/win32cr/media/mediaplayer.cr
+++ b/src/win32cr/media/mediaplayer.cr
@@ -12,9 +12,6 @@ require "../ui/windowsandmessaging.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   CLSID_XFeedsManager = "fe6b11c3-c72e-4061-86c6-9d163121f229"
   WMPGC_FLAGS_ALLOW_PREROLL = 1_u32

--- a/src/win32cr/media/pictureacquisition.cr
+++ b/src/win32cr/media/pictureacquisition.cr
@@ -12,9 +12,6 @@ require "../ui/windowsandmessaging.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   PKEY_PhotoAcquire_RelativePathname = PROPERTYKEY.new(LibC::GUID.new(0xf23377_u32, 0x7ac6_u16, 0x4b7a_u16, StaticArray[0x84_u8, 0x43_u8, 0x34_u8, 0x5e_u8, 0x73_u8, 0x1f_u8, 0xa5_u8, 0x7a_u8]), 2_u32)
   PKEY_PhotoAcquire_FinalFilename = PROPERTYKEY.new(LibC::GUID.new(0xf23377_u32, 0x7ac6_u16, 0x4b7a_u16, StaticArray[0x84_u8, 0x43_u8, 0x34_u8, 0x5e_u8, 0x73_u8, 0x1f_u8, 0xa5_u8, 0x7a_u8]), 3_u32)

--- a/src/win32cr/media/speech.cr
+++ b/src/win32cr/media/speech.cr
@@ -11,9 +11,6 @@ require "../system/com/urlmon.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   SP_LOW_CONFIDENCE = -1_i32
   SP_NORMAL_CONFIDENCE = 0_u32

--- a/src/win32cr/media/streaming.cr
+++ b/src/win32cr/media/streaming.cr
@@ -9,9 +9,6 @@ require "../media/mediafoundation.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
 
   enum MF_TRANSFER_VIDEO_FRAME_FLAGS : Int32

--- a/src/win32cr/networking/backgroundintelligenttransferservice.cr
+++ b/src/win32cr/networking/backgroundintelligenttransferservice.cr
@@ -8,9 +8,6 @@ require "../system/com.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   BG_NOTIFY_JOB_TRANSFERRED = 1_u32
   BG_NOTIFY_JOB_ERROR = 2_u32

--- a/src/win32cr/networking/networklistmanager.cr
+++ b/src/win32cr/networking/networklistmanager.cr
@@ -9,9 +9,6 @@ require "../system/ole.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   NLM_MAX_ADDRESS_LIST_SIZE = 10_u32
   NLM_UNKNOWN_DATAPLAN_STATUS = 4294967295_u32

--- a/src/win32cr/networking/remotedifferentialcompression.cr
+++ b/src/win32cr/networking/remotedifferentialcompression.cr
@@ -8,9 +8,6 @@ require "../foundation.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   RDCE_TABLE_FULL = 2147745793_u32
   RDCE_TABLE_CORRUPT = 2147745794_u32

--- a/src/win32cr/networkmanagement/internetconnectionwizard.cr
+++ b/src/win32cr/networkmanagement/internetconnectionwizard.cr
@@ -7,9 +7,6 @@ require "../foundation.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   ICW_MAX_ACCTNAME = 256_u32
   ICW_MAX_PASSWORD = 256_u32

--- a/src/win32cr/networkmanagement/mobilebroadband.cr
+++ b/src/win32cr/networkmanagement/mobilebroadband.cr
@@ -8,9 +8,6 @@ require "../foundation.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   CLSID_MbnConnectionProfileManager = LibC::GUID.new(0xbdfee05a_u32, 0x4418_u16, 0x11dd_u16, StaticArray[0x90_u8, 0xed_u8, 0x0_u8, 0x1c_u8, 0x25_u8, 0x7c_u8, 0xcf_u8, 0xf1_u8])
   CLSID_MbnInterfaceManager = LibC::GUID.new(0xbdfee05b_u32, 0x4418_u16, 0x11dd_u16, StaticArray[0x90_u8, 0xed_u8, 0x0_u8, 0x1c_u8, 0x25_u8, 0x7c_u8, 0xcf_u8, 0xf1_u8])

--- a/src/win32cr/networkmanagement/ndis.cr
+++ b/src/win32cr/networkmanagement/ndis.cr
@@ -11,9 +11,6 @@ require "../system/remotedesktop.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   IOCTL_NDIS_RESERVED5 = 1507380_u32
   IOCTL_NDIS_RESERVED6 = 1540152_u32

--- a/src/win32cr/networkmanagement/networkpolicyserver.cr
+++ b/src/win32cr/networkmanagement/networkpolicyserver.cr
@@ -8,9 +8,6 @@ require "../foundation.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   RADIUS_EXTENSION_VERSION = 1_u32
   CLSID_SdoMachine = LibC::GUID.new(0xe9218ae7_u32, 0x9e91_u16, 0x11d1_u16, StaticArray[0xbf_u8, 0x60_u8, 0x0_u8, 0x80_u8, 0xc7_u8, 0x84_u8, 0x6b_u8, 0xc0_u8])

--- a/src/win32cr/networkmanagement/windowsconnectnow.cr
+++ b/src/win32cr/networkmanagement/windowsconnectnow.cr
@@ -8,9 +8,6 @@ require "../foundation.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   WCN_E_PEER_NOT_FOUND = -2147206143_i32
   WCN_E_AUTHENTICATION_FAILED = -2147206142_i32

--- a/src/win32cr/networkmanagement/windowsfirewall.cr
+++ b/src/win32cr/networkmanagement/windowsfirewall.cr
@@ -9,9 +9,6 @@ require "../security.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   NETCON_MAX_NAME_LEN = 256_u32
   S_OBJECT_NO_LONGER_VALID = 2_i32

--- a/src/win32cr/security/authentication/identity/provider.cr
+++ b/src/win32cr/security/authentication/identity/provider.cr
@@ -10,9 +10,6 @@ require "../../../system/com/structuredstorage.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   OID_OAssociatedIdentityProviderObject = "98c5a3dd-db68-4f1a-8d2b-9079cdfeaf61"
   CLSID_CoClassIdentityStore = LibC::GUID.new(0x30d49246_u32, 0xd217_u16, 0x465f_u16, StaticArray[0xb0_u8, 0xb_u8, 0xac_u8, 0x9d_u8, 0xdd_u8, 0x65_u8, 0x2e_u8, 0xb7_u8])

--- a/src/win32cr/security/configurationsnapin.cr
+++ b/src/win32cr/security/configurationsnapin.cr
@@ -8,9 +8,6 @@ require "../system/com.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   Cnodetypescetemplateservices = "24a7f717-1f0c-11d1-affb-00c04fb984f9"
   Cnodetypesceanalysisservices = "678050c7-1ff8-11d1-affb-00c04fb984f9"

--- a/src/win32cr/security/networkaccessprotection.cr
+++ b/src/win32cr/security/networkaccessprotection.cr
@@ -7,9 +7,6 @@ require "../foundation.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   ComponentTypeEnforcementClientSoH = 1_u32
   ComponentTypeEnforcementClientRp = 2_u32

--- a/src/win32cr/security/tpm.cr
+++ b/src/win32cr/security/tpm.cr
@@ -8,9 +8,6 @@ require "../foundation.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   TPMVSC_DEFAULT_ADMIN_ALGORITHM_ID = 130_u32
   CLSID_TpmVirtualSmartCardManager = LibC::GUID.new(0x16a18e86_u32, 0x7f6e_u16, 0x4c20_u16, StaticArray[0xad_u8, 0x89_u8, 0x4f_u8, 0xfc_u8, 0xd_u8, 0xb7_u8, 0xa9_u8, 0x6a_u8])

--- a/src/win32cr/security/winwlx.cr
+++ b/src/win32cr/security/winwlx.cr
@@ -10,9 +10,6 @@ require "../ui/windowsandmessaging.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   WLX_VERSION_1_0 = 65536_u32
   WLX_VERSION_1_1 = 65537_u32

--- a/src/win32cr/storage/datadeduplication.cr
+++ b/src/win32cr/storage/datadeduplication.cr
@@ -8,9 +8,6 @@ require "../foundation.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   DEDUP_CHUNKLIB_MAX_CHUNKS_ENUM = 1024_u32
   CLSID_DedupBackupSupport = LibC::GUID.new(0x73d6b2ad_u32, 0x2984_u16, 0x4715_u16, StaticArray[0xb2_u8, 0xe3_u8, 0x92_u8, 0x4c_u8, 0x14_u8, 0x97_u8, 0x44_u8, 0xdd_u8])

--- a/src/win32cr/storage/enhancedstorage.cr
+++ b/src/win32cr/storage/enhancedstorage.cr
@@ -9,9 +9,6 @@ require "../devices/portabledevices.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   GUID_DEVINTERFACE_ENHANCED_STORAGE_SILO = "3897f6a4-fd35-4bc8-a0b7-5dbba36adafa"
   WPD_CATEGORY_ENHANCED_STORAGE = "91248166-b832-4ad4-baa4-7ca0b6b2798c"

--- a/src/win32cr/storage/fileserverresourcemanager.cr
+++ b/src/win32cr/storage/fileserverresourcemanager.cr
@@ -8,9 +8,6 @@ require "../foundation.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   FSRM_DISPID_FEATURE_MASK = 251658240_u32
   FSRM_DISPID_INTERFACE_A_MASK = 15728640_u32

--- a/src/win32cr/storage/packaging/opc.cr
+++ b/src/win32cr/storage/packaging/opc.cr
@@ -10,9 +10,6 @@ require "../../security.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   OPC_E_NONCONFORMING_URI = -2142175231_i32
   OPC_E_RELATIVE_URI_REQUIRED = -2142175230_i32

--- a/src/win32cr/storage/structuredstorage.cr
+++ b/src/win32cr/storage/structuredstorage.cr
@@ -5,9 +5,6 @@
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   alias JET_HANDLE = LibC::UINT_PTR
   alias JET_INSTANCE = LibC::UINT_PTR

--- a/src/win32cr/storage/virtualdiskservice.cr
+++ b/src/win32cr/storage/virtualdiskservice.cr
@@ -8,9 +8,6 @@ require "../system/com.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   VDS_NF_VOLUME_ARRIVE = 4_u32
   VDS_NF_VOLUME_DEPART = 5_u32

--- a/src/win32cr/system/assessmenttool.cr
+++ b/src/win32cr/system/assessmenttool.cr
@@ -11,9 +11,6 @@ require "../ui/accessibility.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   CLSID_CInitiateWinSAT = LibC::GUID.new(0x489331dc_u32, 0xf5e0_u16, 0x4528_u16, StaticArray[0x9f_u8, 0xda_u8, 0x45_u8, 0x33_u8, 0x1b_u8, 0xf4_u8, 0xa5_u8, 0x71_u8])
   CLSID_CQueryWinSAT = LibC::GUID.new(0xf3bdfad3_u32, 0xf276_u16, 0x49e9_u16, StaticArray[0x9b_u8, 0x17_u8, 0xc4_u8, 0x74_u8, 0xf4_u8, 0x8f_u8, 0x7_u8, 0x64_u8])

--- a/src/win32cr/system/com/channelcredentials.cr
+++ b/src/win32cr/system/com/channelcredentials.cr
@@ -8,9 +8,6 @@ require "../../foundation.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
 
   struct IChannelCredentialsVTbl

--- a/src/win32cr/system/com/events.cr
+++ b/src/win32cr/system/com/events.cr
@@ -8,9 +8,6 @@ require "../../foundation.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   CLSID_CEventSystem = LibC::GUID.new(0x4e14fba2_u32, 0x2e22_u16, 0x11d1_u16, StaticArray[0x99_u8, 0x64_u8, 0x0_u8, 0xc0_u8, 0x4f_u8, 0xbb_u8, 0xb3_u8, 0x45_u8])
   CLSID_CEventPublisher = LibC::GUID.new(0xab944620_u32, 0x79c6_u16, 0x11d1_u16, StaticArray[0x88_u8, 0xf9_u8, 0x0_u8, 0x80_u8, 0xc7_u8, 0xd7_u8, 0x71_u8, 0xbf_u8])

--- a/src/win32cr/system/com/ui.cr
+++ b/src/win32cr/system/com/ui.cr
@@ -11,9 +11,6 @@ require "../../ui/windowsandmessaging.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
 
   struct IThumbnailExtractorVTbl

--- a/src/win32cr/system/console.cr
+++ b/src/win32cr/system/console.cr
@@ -8,9 +8,6 @@ require "../security.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   alias HPCON = LibC::IntPtrT
 

--- a/src/win32cr/system/contacts.cr
+++ b/src/win32cr/system/contacts.cr
@@ -8,9 +8,6 @@ require "../foundation.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   CGD_DEFAULT = 0_u32
   CGD_UNKNOWN_PROPERTY = 0_u32

--- a/src/win32cr/system/correlationvector.cr
+++ b/src/win32cr/system/correlationvector.cr
@@ -7,9 +7,6 @@ require "../foundation.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   RTL_CORRELATION_VECTOR_STRING_LENGTH = 129_u32
   RTL_CORRELATION_VECTOR_V1_PREFIX_LENGTH = 16_u32

--- a/src/win32cr/system/desktopsharing.cr
+++ b/src/win32cr/system/desktopsharing.cr
@@ -8,9 +8,6 @@ require "../foundation.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   DISPID_RDPSRAPI_METHOD_OPEN = 100_u32
   DISPID_RDPSRAPI_METHOD_CLOSE = 101_u32

--- a/src/win32cr/system/diagnostics/ceip.cr
+++ b/src/win32cr/system/diagnostics/ceip.cr
@@ -7,9 +7,6 @@ require "../../foundation.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
 
   # Params # 

--- a/src/win32cr/system/diagnostics/debug/webapp.cr
+++ b/src/win32cr/system/diagnostics/debug/webapp.cr
@@ -10,9 +10,6 @@ require "../../../system/diagnostics/debug.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   alias RegisterAuthoringClientFunctionType = Proc(IWebApplicationAuthoringMode, IWebApplicationHost, HRESULT)
   alias UnregisterAuthoringClientFunctionType = Proc(IWebApplicationHost, HRESULT)

--- a/src/win32cr/system/diagnostics/processsnapshotting.cr
+++ b/src/win32cr/system/diagnostics/processsnapshotting.cr
@@ -9,9 +9,6 @@ require "../../system/diagnostics/debug.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   alias HPSS = LibC::IntPtrT
   alias HPSSWALK = LibC::IntPtrT

--- a/src/win32cr/system/diagnostics/toolhelp.cr
+++ b/src/win32cr/system/diagnostics/toolhelp.cr
@@ -7,9 +7,6 @@ require "../../foundation.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   MAX_MODULE_NAME32 = 255_u32
   HF32_DEFAULT = 1_u32

--- a/src/win32cr/system/hostcompute.cr
+++ b/src/win32cr/system/hostcompute.cr
@@ -5,9 +5,6 @@
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   alias HCS_CALLBACK = LibC::IntPtrT
 

--- a/src/win32cr/system/io.cr
+++ b/src/win32cr/system/io.cr
@@ -7,9 +7,6 @@ require "../foundation.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   alias LPOVERLAPPED_COMPLETION_ROUTINE = Proc(UInt32, UInt32, OVERLAPPED*, Void)
 

--- a/src/win32cr/system/ioctl.cr
+++ b/src/win32cr/system/ioctl.cr
@@ -10,9 +10,6 @@ require "../storage/vhd.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   IOCTL_STORAGE_BASE = 45_u32
   IOCTL_SCMBUS_BASE = 89_u32

--- a/src/win32cr/system/kernel.cr
+++ b/src/win32cr/system/kernel.cr
@@ -8,9 +8,6 @@ require "../system/diagnostics/debug.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   OBJ_HANDLE_TAGBITS = 3_i32
   RTL_BALANCED_NODE_RESERVED_PARENT_MASK = 3_u32

--- a/src/win32cr/system/libraryloader.cr
+++ b/src/win32cr/system/libraryloader.cr
@@ -7,9 +7,6 @@ require "../foundation.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   FIND_RESOURCE_DIRECTORY_TYPES = 256_u32
   FIND_RESOURCE_DIRECTORY_NAMES = 512_u32

--- a/src/win32cr/system/mailslots.cr
+++ b/src/win32cr/system/mailslots.cr
@@ -8,9 +8,6 @@ require "../security.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
 
   # Params # lpname : PSTR [In],nmaxmessagesize : UInt32 [In],lreadtimeout : UInt32 [In],lpsecurityattributes : SECURITY_ATTRIBUTES* [In]

--- a/src/win32cr/system/memory/nonvolatile.cr
+++ b/src/win32cr/system/memory/nonvolatile.cr
@@ -6,9 +6,6 @@
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   struct NV_MEMORY_RANGE
     base_address : Void*

--- a/src/win32cr/system/messagequeuing.cr
+++ b/src/win32cr/system/messagequeuing.cr
@@ -8,9 +8,6 @@ require "../foundation.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   PRLT = 0_u32
   PRLE = 1_u32

--- a/src/win32cr/system/mixedreality.cr
+++ b/src/win32cr/system/mixedreality.cr
@@ -5,9 +5,6 @@
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   PERCEPTIONFIELD_StateStream_TimeStamps = "aa886119-f32f-49bf-92ca-f9ddf784d297"
 

--- a/src/win32cr/system/mmc.cr
+++ b/src/win32cr/system/mmc.cr
@@ -11,9 +11,6 @@ require "../ui/windowsandmessaging.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   MMC_VER = 512_u32
   MMC_PROP_CHANGEAFFECTSUI = 1_u32

--- a/src/win32cr/system/parentalcontrols.cr
+++ b/src/win32cr/system/parentalcontrols.cr
@@ -8,9 +8,6 @@ require "../foundation.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   ARRAY_SEP_CHAR = 9_u32
   WPCCHANNEL = 16_u32

--- a/src/win32cr/system/performance/hardwarecounterprofiling.cr
+++ b/src/win32cr/system/performance/hardwarecounterprofiling.cr
@@ -7,9 +7,6 @@ require "../../foundation.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
 
   enum HARDWARE_COUNTER_TYPE : Int32

--- a/src/win32cr/system/processstatus.cr
+++ b/src/win32cr/system/processstatus.cr
@@ -7,9 +7,6 @@ require "../foundation.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   PSAPI_VERSION = 2_u32
 

--- a/src/win32cr/system/realtimecommunications.cr
+++ b/src/win32cr/system/realtimecommunications.cr
@@ -10,9 +10,6 @@ require "../networking/winsock.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   RTCCS_FORCE_PROFILE = 1_u32
   RTCCS_FAIL_ON_REDIRECT = 2_u32

--- a/src/win32cr/system/recovery.cr
+++ b/src/win32cr/system/recovery.cr
@@ -8,9 +8,6 @@ require "../system/windowsprogramming.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
 
   enum REGISTER_APPLICATION_RESTART_FLAGS : UInt32

--- a/src/win32cr/system/remoteassistance.cr
+++ b/src/win32cr/system/remoteassistance.cr
@@ -8,9 +8,6 @@ require "../foundation.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   DISPID_EVENT_ON_STATE_CHANGED = 5_u32
   DISPID_EVENT_ON_TERMINATION = 6_u32

--- a/src/win32cr/system/search/common.cr
+++ b/src/win32cr/system/search/common.cr
@@ -5,9 +5,6 @@
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
 
   enum CONDITION_TYPE : Int32

--- a/src/win32cr/system/serverbackup.cr
+++ b/src/win32cr/system/serverbackup.cr
@@ -8,9 +8,6 @@ require "../foundation.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   WSB_MAX_OB_STATUS_VALUE_TYPE_PAIR = 5_u32
   WSB_MAX_OB_STATUS_ENTRY = 5_u32

--- a/src/win32cr/system/settingsmanagementinfrastructure.cr
+++ b/src/win32cr/system/settingsmanagementinfrastructure.cr
@@ -8,9 +8,6 @@ require "../foundation.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   WCM_SETTINGS_ID_FLAG_REFERENCE = 0_u32
   WCM_SETTINGS_ID_FLAG_DEFINITION = 1_u32

--- a/src/win32cr/system/setupandmigration.cr
+++ b/src/win32cr/system/setupandmigration.cr
@@ -7,9 +7,6 @@ require "../foundation.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   alias OOBE_COMPLETED_CALLBACK = Proc(Void*, Void)
 

--- a/src/win32cr/system/sideshow.cr
+++ b/src/win32cr/system/sideshow.cr
@@ -11,9 +11,6 @@ require "../system/com/structuredstorage.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   SIDESHOW_ENDPOINT_SIMPLE_CONTENT_FORMAT = "a9a5353f-2d4b-47ce-93ee-759f3a7dda4f"
   SIDESHOW_ENDPOINT_ICAL = "4dff36b5-9dde-4f76-9a2a-96435047063d"

--- a/src/win32cr/system/taskscheduler.cr
+++ b/src/win32cr/system/taskscheduler.cr
@@ -9,9 +9,6 @@ require "../ui/controls.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   TASK_SUNDAY = 1_u32
   TASK_MONDAY = 2_u32

--- a/src/win32cr/system/transactionserver.cr
+++ b/src/win32cr/system/transactionserver.cr
@@ -8,9 +8,6 @@ require "../foundation.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   CLSID_Catalog = LibC::GUID.new(0x6eb22881_u32, 0x8a19_u16, 0x11d0_u16, StaticArray[0x81_u8, 0xb6_u8, 0x0_u8, 0xa0_u8, 0xc9_u8, 0x23_u8, 0x1c_u8, 0x29_u8])
   CLSID_CatalogObject = LibC::GUID.new(0x6eb22882_u32, 0x8a19_u16, 0x11d0_u16, StaticArray[0x81_u8, 0xb6_u8, 0x0_u8, 0xa0_u8, 0xc9_u8, 0x23_u8, 0x1c_u8, 0x29_u8])

--- a/src/win32cr/system/updateagent.cr
+++ b/src/win32cr/system/updateagent.cr
@@ -8,9 +8,6 @@ require "../foundation.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   LIBID_WUApiLib = "b596cc9f-56e5-419e-a622-e01bb457431e"
   UPDATE_LOCKDOWN_WEBSITE_ACCESS = 1_u32

--- a/src/win32cr/system/updateassessment.cr
+++ b/src/win32cr/system/updateassessment.cr
@@ -8,9 +8,6 @@ require "../system/com.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   CLSID_WaaSAssessor = LibC::GUID.new(0x98ef871_u32, 0xfa9f_u16, 0x46af_u16, StaticArray[0x89_u8, 0x58_u8, 0xc0_u8, 0x83_u8, 0x51_u8, 0x5d_u8, 0x7c_u8, 0x9c_u8])
 

--- a/src/win32cr/system/virtualdosmachines.cr
+++ b/src/win32cr/system/virtualdosmachines.cr
@@ -9,9 +9,6 @@ require "../system/diagnostics/debug.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   VDMCONTEXT_i386 = 65536_u32
   VDMCONTEXT_i486 = 65536_u32

--- a/src/win32cr/system/windowssync.cr
+++ b/src/win32cr/system/windowssync.cr
@@ -9,9 +9,6 @@ require "../ui/shell/propertiessystem.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   SYNC_VERSION_FLAG_FROM_FEED = 1_u32
   SYNC_VERSION_FLAG_HAS_BY = 2_u32

--- a/src/win32cr/system/winrt/alljoyn.cr
+++ b/src/win32cr/system/winrt/alljoyn.cr
@@ -8,9 +8,6 @@ require "../../foundation.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
 
   struct IWindowsDevicesAllJoynBusAttachmentInteropVTbl

--- a/src/win32cr/system/winrt/composition.cr
+++ b/src/win32cr/system/winrt/composition.cr
@@ -10,9 +10,6 @@ require "../../system/winrt.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
 
   struct ICompositionDrawingSurfaceInteropVTbl

--- a/src/win32cr/system/winrt/coreinputview.cr
+++ b/src/win32cr/system/winrt/coreinputview.cr
@@ -8,9 +8,6 @@ require "../../foundation.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
 
   struct ICoreFrameworkInputViewInteropVTbl

--- a/src/win32cr/system/winrt/display.cr
+++ b/src/win32cr/system/winrt/display.cr
@@ -10,9 +10,6 @@ require "../../security.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
 
   struct IDisplayDeviceInteropVTbl

--- a/src/win32cr/system/winrt/graphics/capture.cr
+++ b/src/win32cr/system/winrt/graphics/capture.cr
@@ -9,9 +9,6 @@ require "../../../graphics/gdi.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
 
   struct IGraphicsCaptureItemInteropVTbl

--- a/src/win32cr/system/winrt/graphics/direct2d.cr
+++ b/src/win32cr/system/winrt/graphics/direct2d.cr
@@ -9,9 +9,6 @@ require "../../../graphics/direct2d.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
 
   enum GRAPHICS_EFFECT_PROPERTY_MAPPING : Int32

--- a/src/win32cr/system/winrt/graphics/imaging.cr
+++ b/src/win32cr/system/winrt/graphics/imaging.cr
@@ -10,9 +10,6 @@ require "../../../media/mediafoundation.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   CLSID_SoftwareBitmapNativeFactory = "84e65691-8602-4a84-be46-708be9cd4b74"
 

--- a/src/win32cr/system/winrt/holographic.cr
+++ b/src/win32cr/system/winrt/holographic.cr
@@ -9,9 +9,6 @@ require "../../graphics/direct3d12.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
 
   struct IHolographicCameraInteropVTbl

--- a/src/win32cr/system/winrt/isolation.cr
+++ b/src/win32cr/system/winrt/isolation.cr
@@ -8,9 +8,6 @@ require "../../foundation.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
 
   struct IIsolatedEnvironmentInteropVTbl

--- a/src/win32cr/system/winrt/media.cr
+++ b/src/win32cr/system/winrt/media.cr
@@ -9,9 +9,6 @@ require "../../media/mediafoundation.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   CLSID_AudioFrameNativeFactory = "16a0a3b9-9f65-4102-9367-2cda3a4f372a"
   CLSID_VideoFrameNativeFactory = "d194386a-04e3-4814-8100-b2b0ae6d78c7"

--- a/src/win32cr/system/winrt/ml.cr
+++ b/src/win32cr/system/winrt/ml.cr
@@ -10,9 +10,6 @@ require "../../graphics/direct3d12.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
 
   struct ILearningModelOperatorProviderNativeVTbl

--- a/src/win32cr/system/winrt/printing.cr
+++ b/src/win32cr/system/winrt/printing.cr
@@ -11,9 +11,6 @@ require "../../graphics/printing.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
 
   struct IPrinting3DManagerInteropVTbl

--- a/src/win32cr/system/winrt/shell.cr
+++ b/src/win32cr/system/winrt/shell.cr
@@ -9,9 +9,6 @@ require "../../ui/shell.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
 
   enum CreateProcessMethod : Int32

--- a/src/win32cr/system/winrt/storage.cr
+++ b/src/win32cr/system/winrt/storage.cr
@@ -8,9 +8,6 @@ require "../../foundation.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
 
   enum HANDLE_OPTIONS : UInt32

--- a/src/win32cr/system/winrt/xaml.cr
+++ b/src/win32cr/system/winrt/xaml.cr
@@ -10,9 +10,6 @@ require "../../ui/windowsandmessaging.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   E_SURFACE_CONTENTS_LOST = 2150301728_u32
 

--- a/src/win32cr/ui/animation.cr
+++ b/src/win32cr/ui/animation.cr
@@ -9,9 +9,6 @@ require "../graphics/directcomposition.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   alias UI_ANIMATION_KEYFRAME = LibC::IntPtrT
 

--- a/src/win32cr/ui/controls/richedit.cr
+++ b/src/win32cr/ui/controls/richedit.cr
@@ -15,9 +15,6 @@ require "../../system/com/structuredstorage.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   WM_CONTEXTMENU = 123_u32
   WM_UNICHAR = 265_u32

--- a/src/win32cr/ui/input/ink.cr
+++ b/src/win32cr/ui/input/ink.cr
@@ -8,9 +8,6 @@ require "../../foundation.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   CLSID_InkDesktopHost = LibC::GUID.new(0x62584a6_u32, 0xf830_u16, 0x4bdc_u16, StaticArray[0xa4_u8, 0xd2_u8, 0xa_u8, 0x10_u8, 0xab_u8, 0x6_u8, 0x2b_u8, 0x1d_u8])
   CLSID_InkD2DRenderer = LibC::GUID.new(0x4044e60c_u32, 0x7b01_u16, 0x4671_u16, StaticArray[0xa9_u8, 0x7c_u8, 0x4_u8, 0xe0_u8, 0x21_u8, 0xa_u8, 0x7_u8, 0xa5_u8])

--- a/src/win32cr/ui/input/radial.cr
+++ b/src/win32cr/ui/input/radial.cr
@@ -8,9 +8,6 @@ require "../../foundation.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
 
   struct IRadialControllerInteropVTbl

--- a/src/win32cr/ui/legacywindowsenvironmentfeatures.cr
+++ b/src/win32cr/ui/legacywindowsenvironmentfeatures.cr
@@ -11,9 +11,6 @@ require "../system/ole.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   EVCF_HASSETTINGS = 1_u32
   EVCF_ENABLEBYDEFAULT = 2_u32

--- a/src/win32cr/ui/notifications.cr
+++ b/src/win32cr/ui/notifications.cr
@@ -8,9 +8,6 @@ require "../system/com.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   struct NOTIFICATION_USER_INPUT_DATA
     key : LibC::LPWSTR

--- a/src/win32cr/ui/ribbon.cr
+++ b/src/win32cr/ui/ribbon.cr
@@ -11,9 +11,6 @@ require "../graphics/gdi.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   UI_ALL_COMMANDS = 0_u32
   UI_COLLECTION_INVALIDINDEX = 4294967295_u32

--- a/src/win32cr/ui/shell/common.cr
+++ b/src/win32cr/ui/shell/common.cr
@@ -8,9 +8,6 @@ require "../../system/com.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   PERCEIVEDFLAG_UNDEFINED = 0_u32
   PERCEIVEDFLAG_SOFTCODED = 1_u32

--- a/src/win32cr/ui/wpf.cr
+++ b/src/win32cr/ui/wpf.cr
@@ -10,9 +10,6 @@ require "../graphics/dwm.cr"
 {% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
 @[Link(ldflags: "/IGNORE:4199")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.8.2") <= 0 %}
-{% else %}
-{% end %}
 lib LibWin32
   MILBITMAPEFFECT_SDK_VERSION = 16777216_u32
   CLSID_MILBitmapEffectGroup = "ac9c1a9a-7e18-4f64-ac7e-47cf7f051e95"


### PR DESCRIPTION
These empty macro conditionals were created by the program used to generate from the metadata before it was told to skip if there were no libraries to link against.