### PR TITLE
Obtain version from shard.yml

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,9 +1,9 @@
 name: win32cr
-version: 0.3.1
+version: 0.3.2
 
 authors:
   - Matthew J. Black <mjblack@gmail.com>
 
-crystal: 1.8.1
+crystal: 1.9.2
 
 license: MIT

--- a/src/win32cr.cr
+++ b/src/win32cr.cr
@@ -13,7 +13,7 @@ struct LibC::GUID
 end
 
 module Win32cr
-  VERSION = "0.3.1"
+  VERSION = {{ `shards version`.chomp.stringify }}
 end
 
 class ComPtr(T)


### PR DESCRIPTION
Win32::VERSION is set via macro. Shard version bumped to 0.3.2.