### PR TITLE
Fix VERSION to report correct value

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: win32cr
-version: 0.3.2
+version: 0.3.3
 
 authors:
   - Matthew J. Black <mjblack@gmail.com>

--- a/src/win32cr.cr
+++ b/src/win32cr.cr
@@ -13,7 +13,7 @@ struct LibC::GUID
 end
 
 module Win32cr
-  VERSION = {{ `shards version`.chomp.stringify }}
+  VERSION = {{ `shards version #{__DIR__}`.chomp.stringify }}
 end
 
 class ComPtr(T)


### PR DESCRIPTION
When included as a library, Win32cr::VERSION would report the version from the shard.yml of the application being built and not the library itself. This change updates the call to use __DIR__ to get the correct value.

Closes #28