### PR TITLE
Fix vertdll linker error

### DIFF
--- a/src/win32cr/system/environment.cr
+++ b/src/win32cr/system/environment.cr
@@ -14,7 +14,9 @@ require "../foundation.cr"
 {% else %}
 @[Link("userenv")]
 @[Link("onecore")]
+{% if flag?(:preview_dll)%}
 @[Link("vertdll")]
+{% end %}
 {% end %}
 lib LibWin32
   ENCLAVE_RUNTIME_POLICY_ALLOW_FULL_DEBUG = 1_u32

--- a/src/win32cr/system/threading.cr
+++ b/src/win32cr/system/threading.cr
@@ -17,7 +17,9 @@ require "../system/systeminformation.cr"
 @[Link(ldflags: "/DELAYLOAD:onecore.dll")]
 @[Link(ldflags: "/DELAYLOAD:user32.dll")]
 {% else %}
+{% if flag?(:preview_dll)%}
 @[Link("vertdll")]
+{% end %}
 @[Link("advapi32")]
 @[Link("onecore")]
 @[Link("user32")]


### PR DESCRIPTION
vertdll includes memcpy as does the library libvcruntime. The issue doesn't occur if you use the preview_dll flag as vcruntime is used over libvcruntime. This change makes loading vertdll library only occur when preview_dll flag is set.

Closes #29