### PR TITLE
Fix two environment unicode functions defs

### DIFF
--- a/spec/system/environment_spec.cr
+++ b/spec/system/environment_spec.cr
@@ -1,0 +1,39 @@
+require "../spec_helper"
+require "../../src/win32cr/system/environment"
+
+module Win32::System
+  describe "Win32::System::Environment" do
+    var_value = "Environment"
+
+
+    describe "Setting environment variable" do
+      result = LibC.SetEnvironmentVariableW("CrystalSpec".to_utf16, var_value.to_utf16)
+
+      it "result should be greater than zero" do
+        result.should be > 0
+      end
+    end
+
+    describe "Reading environment variable" do
+      size = LibC.GetEnvironmentVariableW("CrystalSpec".to_utf16, nil, 0)
+      lpwch = Pointer(UInt16).malloc(size)
+      LibC.GetEnvironmentVariableW("CrystalSpec".to_utf16, lpwch, size)
+      str = String.from_utf16(lpwch).first
+
+      it "string should be the previously set variable" do
+        str.should contain(var_value)
+      end
+    end
+
+    describe "Expanding variable" do
+      size = LibWin32.ExpandEnvironmentStringsW("%CrystalSpec%".to_utf16, nil, 0)
+      lpwch = Pointer(UInt16).malloc(size)
+      LibWin32.ExpandEnvironmentStringsW("%CrystalSpec%".to_utf16, lpwch, size)
+      str = String.from_utf16(lpwch).first
+
+      it "string expanded should be the previously set variable" do
+        str.should contain(var_value)
+      end
+    end
+  end
+end

--- a/src/win32cr/system/environment.cr
+++ b/src/win32cr/system/environment.cr
@@ -198,7 +198,7 @@ lib LibWin32
   fun ExpandEnvironmentStringsA(lpsrc : PSTR, lpdst : UInt8*, nsize : UInt32) : UInt32
 
   # Params # lpsrc : LibC::LPWSTR [In],lpdst : Char* [In],nsize : UInt32 [In]
-  fun ExpandEnvironmentStringsW(lpsrc : LibC::LPWSTR, lpdst : Char*, nsize : UInt32) : UInt32
+  fun ExpandEnvironmentStringsW(lpsrc : LibC::LPWSTR, lpdst : UInt16*, nsize : UInt32) : UInt32
 
   # Params # lppathname : PSTR [In]
   fun SetCurrentDirectoryA(lppathname : PSTR) : LibC::BOOL
@@ -230,7 +230,7 @@ lib LibWin32
   fun ExpandEnvironmentStringsForUserA(htoken : LibC::HANDLE, lpsrc : PSTR, lpdest : UInt8*, dwsize : UInt32) : LibC::BOOL
 
   # Params # htoken : LibC::HANDLE [In],lpsrc : LibC::LPWSTR [In],lpdest : Char* [In],dwsize : UInt32 [In]
-  fun ExpandEnvironmentStringsForUserW(htoken : LibC::HANDLE, lpsrc : LibC::LPWSTR, lpdest : Char*, dwsize : UInt32) : LibC::BOOL
+  fun ExpandEnvironmentStringsForUserW(htoken : LibC::HANDLE, lpsrc : LibC::LPWSTR, lpdest : UInt16*, dwsize : UInt32) : LibC::BOOL
 
   # Params # flenclavetype : UInt32 [In]
   fun IsEnclaveTypeSupported(flenclavetype : UInt32) : LibC::BOOL


### PR DESCRIPTION
Char* is used for the destination when it should be UInt16. Added spec tests for environment.