### PR TITLE
Updated CI Workflow and Shard dependencies

### DIFF
--- a/.github/workflows/crystal.yml
+++ b/.github/workflows/crystal.yml
@@ -13,9 +13,14 @@ on:
           - warning
           - debug
   push:
-    branches: [ "master" ]
+    branches:
+      - master
+      - 'development/**'
   pull_request:
-    branches: [ "master" ]
+    branches:
+      - master
+      - 'development/**'
+    types: [opened, reopened, ready_for_review, review_requested]
 
 jobs:
   build:

--- a/shard.yml
+++ b/shard.yml
@@ -8,6 +8,6 @@ crystal: ">= 1.15.0"
 
 license: MIT
 
-development_dependencies:
+dependencies:
   winmd:
     github: mjblack/winmd


### PR DESCRIPTION
Updated CI workflow on the initiators of workflow triggers. 

Updated shard.yml to rename `development_dependencies` to `dependencies` so that WinMD is provided when this shard is a dependency. 